### PR TITLE
Inject receipt expense service dependency

### DIFF
--- a/hasta_la_vista_money/expense/containers.py
+++ b/hasta_la_vista_money/expense/containers.py
@@ -13,6 +13,7 @@ class ExpenseContainer(containers.DeclarativeContainer):
     expense_service = providers.Factory(
         ExpenseService,
         account_service=core.account_service,
+        receipt_expense_service_factory=receipt_expense_service.provider,
     )
     expense_category_service = providers.Factory(ExpenseCategoryService)
     receipt_expense_service = providers.Factory(ReceiptExpenseService)

--- a/hasta_la_vista_money/expense/tests/test_services.py
+++ b/hasta_la_vista_money/expense/tests/test_services.py
@@ -40,6 +40,7 @@ class TestExpenseService(TestCase):
             self.user,
             self.request,
             self.mock_account_service,
+            ReceiptExpenseService,
         )
 
     def tearDown(self) -> None:


### PR DESCRIPTION
## Summary
- instantiate the receipt expense service through dependency injection in `ExpenseService`
- wire the expense container to pass the receipt service factory and adjust tests for the new dependency

## Testing
- `python manage.py test hasta_la_vista_money.expense.tests.test_services -k Expense` *(fails: Django not installed in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fe897b0c88327933351bb597340be)