### PR TITLE
Harden loading of external scripts and upload previews

### DIFF
--- a/static/js/expense_table.js
+++ b/static/js/expense_table.js
@@ -323,6 +323,7 @@ function initExpensePage() {
             'https://unpkg.com/tabulator-tables@6.3.1/dist/js/tabulator.min.js',
             'https://cdn.jsdelivr.net/npm/tabulator-tables@6.3.1/dist/js/tabulator.min.js',
         ];
+        const allowedSources = new Set(sources);
 
         function tryLoad(srcIndex) {
             if (srcIndex >= sources.length) {
@@ -346,13 +347,19 @@ function initExpensePage() {
                 return;
             }
             const srcValue = sourceArray[srcIndex];
-            if (typeof srcValue !== 'string' || !/^https?:\/\//.test(srcValue)) {
+            if (typeof srcValue !== 'string' || !allowedSources.has(srcValue)) {
                 tryLoad(srcIndex + 1);
                 return;
             }
             const script = document.createElement('script');
-            const validatedSrc = String(srcValue);
-            script.setAttribute('src', validatedSrc);
+            let validatedSrc;
+            try {
+                validatedSrc = new URL(srcValue).toString();
+            } catch (error) {
+                tryLoad(srcIndex + 1);
+                return;
+            }
+            script.src = validatedSrc;
             script.setAttribute('async', 'true');
             script.onload = function () {
                 if (typeof window.Tabulator !== 'undefined') {

--- a/static/js/income_table.js
+++ b/static/js/income_table.js
@@ -327,6 +327,7 @@ function initIncomePage() {
             'https://unpkg.com/tabulator-tables@6.3.1/dist/js/tabulator.min.js',
             'https://cdn.jsdelivr.net/npm/tabulator-tables@6.3.1/dist/js/tabulator.min.js',
         ];
+        const allowedSources = new Set(sources);
 
         function tryLoad(srcIndex) {
             if (srcIndex >= sources.length) {
@@ -350,13 +351,19 @@ function initIncomePage() {
                 return;
             }
             const srcValue = sourceArray[srcIndex];
-            if (typeof srcValue !== 'string' || !/^https?:\/\//.test(srcValue)) {
+            if (typeof srcValue !== 'string' || !allowedSources.has(srcValue)) {
                 tryLoad(srcIndex + 1);
                 return;
             }
             const script = document.createElement('script');
-            const validatedSrc = String(srcValue);
-            script.setAttribute('src', validatedSrc);
+            let validatedSrc;
+            try {
+                validatedSrc = new URL(srcValue).toString();
+            } catch (error) {
+                tryLoad(srcIndex + 1);
+                return;
+            }
+            script.src = validatedSrc;
             script.setAttribute('async', 'true');
             script.onload = function () {
                 if (typeof window.Tabulator !== 'undefined') {

--- a/static/js/upload.js
+++ b/static/js/upload.js
@@ -118,7 +118,9 @@
             }
 
             revokeObjectUrl();
-            objectUrl = URL.createObjectURL(file);
+            const safeMime = (file.type && file.type.startsWith('image/')) ? file.type : 'image/jpeg';
+            const safeBlob = new Blob([file], { type: safeMime });
+            objectUrl = URL.createObjectURL(safeBlob);
             previewImage.src = objectUrl;
             preview.classList.remove('hidden');
 


### PR DESCRIPTION
## Summary
- whitelist Tabulator CDN sources and validate them before injecting script tags
- parse and guard script URLs with fallback to the next source on errors
- ensure upload previews use image-safe blobs before setting the preview source

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69430744386883278ee3d3bb4bbf6b05)