### PR TITLE
Fix Tabulator table layout without CDN styles

### DIFF
--- a/static/css/styles.min.css
+++ b/static/css/styles.min.css
@@ -6201,6 +6201,38 @@
     table-layout: auto;
     width: 100%;
   }
+  .tabulator,.tabulator * {
+    box-sizing: border-box;
+  }
+  .tabulator .tabulator-header,.tabulator .tabulator-tableholder {
+    position: relative;
+    width: 100%;
+  }
+  .tabulator .tabulator-tableholder {
+    overflow: auto;
+  }
+  .tabulator .tabulator-table {
+    position: relative;
+    white-space: nowrap;
+  }
+  .tabulator .tabulator-header .tabulator-headers {
+    display: flex;
+    flex-wrap: nowrap;
+    align-items: stretch;
+    width: max-content;
+  }
+  .tabulator .tabulator-header .tabulator-col,.tabulator .tabulator-header .tabulator-col-group {
+    position: relative;
+    display: flex !important;
+    flex-direction: column;
+    justify-content: center;
+    vertical-align: top;
+  }
+  .tabulator .tabulator-header .tabulator-col-group .tabulator-col-group-cols {
+    display: flex;
+    flex-wrap: nowrap;
+    width: 100%;
+  }
   @media (max-width: 991px) {
     .tabulator {
       min-width: 100%;
@@ -6380,6 +6412,15 @@
   .tabulator .tabulator-table .tabulator-row .tabulator-cell {
     display: block !important;
     flex: 0 0 auto !important;
+  }
+  .tabulator .tabulator-row .tabulator-cell.tabulator-frozen,.tabulator .tabulator-header .tabulator-col.tabulator-frozen {
+    position: sticky;
+    left: 0;
+    z-index: 20;
+    background: inherit;
+  }
+  .tabulator .tabulator-header .tabulator-col.tabulator-frozen {
+    z-index: 25;
   }
   .tabulator .tabulator-table .tabulator-row .tabulator-col-resize-handle {
     flex: 0 0 auto !important;

--- a/theme/static_src/src/tabulator-tailwind.css
+++ b/theme/static_src/src/tabulator-tailwind.css
@@ -20,6 +20,48 @@
     width: 100%;
   }
 
+  .tabulator,
+  .tabulator * {
+    box-sizing: border-box;
+  }
+
+  .tabulator .tabulator-header,
+  .tabulator .tabulator-tableholder {
+    position: relative;
+    width: 100%;
+  }
+
+  .tabulator .tabulator-tableholder {
+    overflow: auto;
+  }
+
+  .tabulator .tabulator-table {
+    position: relative;
+    white-space: nowrap;
+  }
+
+  .tabulator .tabulator-header .tabulator-headers {
+    display: flex;
+    flex-wrap: nowrap;
+    align-items: stretch;
+    width: max-content;
+  }
+
+  .tabulator .tabulator-header .tabulator-col,
+  .tabulator .tabulator-header .tabulator-col-group {
+    position: relative;
+    display: flex !important;
+    flex-direction: column;
+    justify-content: center;
+    vertical-align: top;
+  }
+
+  .tabulator .tabulator-header .tabulator-col-group .tabulator-col-group-cols {
+    display: flex;
+    flex-wrap: nowrap;
+    width: 100%;
+  }
+
   @media (max-width: 991px) {
     .tabulator {
       min-width: 100%;
@@ -104,6 +146,18 @@
   .tabulator .tabulator-table .tabulator-row .tabulator-cell {
     display: block !important;
     flex: 0 0 auto !important;
+  }
+
+  .tabulator .tabulator-row .tabulator-cell.tabulator-frozen,
+  .tabulator .tabulator-header .tabulator-col.tabulator-frozen {
+    position: sticky;
+    left: 0;
+    z-index: 20;
+    background: inherit;
+  }
+
+  .tabulator .tabulator-header .tabulator-col.tabulator-frozen {
+    z-index: 25;
   }
 
   .tabulator .tabulator-table .tabulator-row .tabulator-col-resize-handle {


### PR DESCRIPTION
## Summary
- rely on local Tabulator styling instead of the CDN stylesheet
- add structural Tabulator layout rules to keep headers and rows aligned horizontally and honor frozen columns
- sync compiled CSS bundle with the updated Tabulator styles

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943f74b24b4832795cec2063354993e)