### PR TITLE
refactor(config): replace env validator debug output with structured logs

### DIFF
--- a/config/django/tests/test_validator_env.py
+++ b/config/django/tests/test_validator_env.py
@@ -8,14 +8,18 @@ from config.django.validator_env import EnvironmentValidator
 class EnvironmentValidatorTest(SimpleTestCase):
     def test_validate_returns_true_for_ci_environment(self) -> None:
         with patch.dict(
-            'config.django.validator_env.environ', {'CI': '1'}, clear=True
+            'config.django.validator_env.environ',
+            {'CI': '1'},
+            clear=True,
         ):
             validator = EnvironmentValidator()
             self.assertTrue(validator.validate())
 
     def test_validate_returns_false_when_variables_missing(self) -> None:
         def fake_config(
-            key: str, cast: type[str] | type[bool] = str, default: str = ''
+            key: str,
+            cast: type[str] | type[bool] = str,
+            default: str = '',
         ) -> str | bool:
             values: dict[str, object] = {
                 'SECRET_KEY': '',
@@ -31,17 +35,20 @@ class EnvironmentValidatorTest(SimpleTestCase):
         with (
             patch.dict('config.django.validator_env.environ', {}, clear=True),
             patch(
-                'config.django.validator_env.config', side_effect=fake_config
+                'config.django.validator_env.config',
+                side_effect=fake_config,
             ),
-            patch('config.django.validator_env.ic') as mock_ic,
+            patch('config.django.validator_env.logger.warning') as mock_warning,
         ):
             validator = EnvironmentValidator()
             self.assertFalse(validator.validate())
-            self.assertGreaterEqual(mock_ic.call_count, 4)
+            self.assertGreaterEqual(mock_warning.call_count, 4)
 
     def test_validate_returns_true_with_complete_configuration(self) -> None:
         def fake_config(
-            key: str, cast: type[str] | type[bool] = str, default: str = ''
+            key: str,
+            cast: type[str] | type[bool] = str,
+            default: str = '',
         ) -> str | bool:
             values: dict[str, object] = {
                 'SECRET_KEY': 'secret',
@@ -57,9 +64,10 @@ class EnvironmentValidatorTest(SimpleTestCase):
         with (
             patch.dict('config.django.validator_env.environ', {}, clear=True),
             patch(
-                'config.django.validator_env.config', side_effect=fake_config
+                'config.django.validator_env.config',
+                side_effect=fake_config,
             ),
-            patch('config.django.validator_env.ic'),
+            patch('config.django.validator_env.logger.warning'),
         ):
             validator = EnvironmentValidator()
             self.assertTrue(validator.validate())

--- a/config/django/validator_env.py
+++ b/config/django/validator_env.py
@@ -1,7 +1,9 @@
 from os import environ
 
+import structlog
 from decouple import config
-from icecream import ic
+
+logger = structlog.get_logger(__name__)
 
 
 class EnvironmentValidator:
@@ -17,16 +19,25 @@ class EnvironmentValidator:
         valid = True
         if not config('SECRET_KEY', cast=str, default=''):
             valid = False
-            ic('SECRET_KEY is not set, use make secretkey to generate it')
+            logger.warning(
+                'Required environment variable is not set',
+                variable='SECRET_KEY',
+                hint='Use make secretkey to generate it',
+            )
         if not config('ALLOWED_HOSTS', cast=str, default=''):
             valid = False
-            ic(
-                'ALLOWED_HOSTS is not set, set it to a '
-                'comma-separated list of hosts',
+            logger.warning(
+                'Required environment variable is not set',
+                variable='ALLOWED_HOSTS',
+                hint='Set it to a comma-separated list of hosts',
             )
         if not config('DATABASE_URL', cast=str, default=''):
             valid = False
-            ic('DATABASE_URL is not set, set it to a valid database URL')
+            logger.warning(
+                'Required environment variable is not set',
+                variable='DATABASE_URL',
+                hint='Set it to a valid database URL',
+            )
 
         debug_mode = config('DEBUG', default=False, cast=bool)
         allowed_hosts_str = config('ALLOWED_HOSTS', cast=str, default='')
@@ -52,8 +63,10 @@ class EnvironmentValidator:
             )
         ):
             valid = False
-            ic(
-                'REDIS_LOCATION is not set for production, set it to redis://host:port/db',
+            logger.warning(
+                'Production environment variable is not set',
+                variable='REDIS_LOCATION',
+                hint='Set it to redis://host:port/db',
             )
 
         return valid


### PR DESCRIPTION
Swap ad hoc `icecream` messages for `structlog` warnings in the Django environment validator so missing configuration is reported in a consistent, production-friendly format.

This keeps validation feedback intact while making error tracking and log aggregation easier to consume across environments.