### PR TITLE
docs: clarify self-hosted production setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,41 +1,58 @@
-# Django Settings
-SECRET_KEY=your-secret-key-here-generate-new-one
+# Django settings
+DJANGO_SETTINGS_MODULE=config.django.prod
+SECRET_KEY=replace-with-generated-secret-key
 DEBUG=false
-ALLOWED_HOSTS=localhost,127.0.0.1
-BASE_URL=http://127.0.0.1:8000/
-CSRF_TRUSTED_ORIGINS=http://localhost:8000
+ALLOWED_HOSTS=money.example.com
+BASE_URL=https://money.example.com/
+CSRF_TRUSTED_ORIGINS=https://money.example.com
 
-# Database
-DATABASE_URL=postgresql://user:password@localhost:5432/dbname
-# OR
-POSTGRES_DB=hastalavistamoney
-POSTGRES_USER=postgres
-POSTGRES_PASSWORD=postgres
-POSTGRES_HOST=localhost
-POSTGRES_PORT=5432
+# Database and cache
+# For bundled docker-compose.prod.yaml Postgres, set POSTGRES_* below.
+# DATABASE_URL is only needed for an external PostgreSQL instance.
+REDIS_LOCATION=redis://redis:6379/0
+
+# Bundled Postgres configuration for docker-compose.prod.yaml
+POSTGRES_DB=hlvm
+POSTGRES_USER=hlvm
+POSTGRES_PASSWORD=replace-with-db-password
+
+# Optional: external PostgreSQL instead of bundled db service
+# DATABASE_URL=postgresql://hlvm:replace-with-db-password@db.example.com:5432/hlvm
 
 # Localization
 LANGUAGE_CODE=ru-RU
 TIME_ZONE=Europe/Moscow
 
-# Security
+# Cookie and transport security
 SESSION_COOKIE_SECURE=true
+SESSION_COOKIE_HTTPONLY=true
+SESSION_COOKIE_SAMESITE=Lax
+CSRF_COOKIE_SECURE=true
+SECURE_SSL_REDIRECT=true
+SECURE_CONTENT_TYPE_NOSNIFF=true
+SECURE_HSTS_SECONDS=31536000
+SECURE_HSTS_INCLUDE_SUBDOMAINS=true
+SECURE_HSTS_PRELOAD=true
+
+# Session lifetime
 SESSION_COOKIE_AGE=604800
 
-# JWT Tokens
+# JWT tokens
 ACCESS_TOKEN_LIFETIME=60
 REFRESH_TOKEN_LIFETIME=7
 
-# Error tracking (optional)
+# Sentry-compatible error tracking
+# Leave empty only if you intentionally do not use error tracking.
 ERROR_TRACKING_DSN=
 ERROR_TRACKING_ENVIRONMENT=production
 
-# CORS (optional)
+# Optional CSP overrides
 URL_CSP_SCRIPT_SRC=
 
 # Receipts
 PENDING_RECEIPT_EXPIRY_HOURS=24
 
+# AI provider configuration
 AI_PROVIDER=openai/anthropic
 
 OPENAI_API_KEY=

--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ docker compose up -d
 
 > 💡 **Совет:** При первом запуске приложение автоматически создаст SQLite базу данных. Для production рекомендуется использовать PostgreSQL.
 
+> 🔒 **Важно:** Блок выше описывает быстрый локальный/self-hosted запуск, а не production minimum. Для production self-hosted используйте отдельное руководство: [docs/docs/production_self_hosted.md](docs/docs/production_self_hosted.md)
+
 ### Первые шаги
 1. Зарегистрируйте аккаунт администратора
 2. Создайте свой первый финансовый счет
@@ -141,19 +143,48 @@ docker compose up -d
 |-----------|----------|----------------------|
 | `SECRET_KEY` | Секретный ключ Django (обязательно) | - |
 | `DEBUG` | Режим отладки | `false` |
-| `ALLOWED_HOSTS` | Разрешенные хосты | `localhost,127.0.0.1` |
-| `DATABASE_URL` | URL PostgreSQL (опционально) | SQLite |
-| `REDIS_LOCATION` | URL Redis для кеширования (продакшен) | - |
-| `ERROR_TRACKING_DSN` | DSN для Bugsink-compatible error tracking | - |
-| `ERROR_TRACKING_ENVIRONMENT` | Окружение для error tracking | - |
+| `ALLOWED_HOSTS` | Разрешенные production-хосты | - |
+| `CSRF_TRUSTED_ORIGINS` | Доверенные HTTPS-источники для CSRF | - |
+| `DATABASE_URL` | URL PostgreSQL для production-окружения | - |
+| `REDIS_LOCATION` | URL Redis для кеширования, сессий и Celery в production | - |
+| `ERROR_TRACKING_DSN` | DSN для Sentry-compatible мониторинга ошибок | - |
+| `ERROR_TRACKING_ENVIRONMENT` | Окружение для мониторинга ошибок | `production` |
+| `SESSION_COOKIE_SECURE` | Флаг `Secure` для session cookie | `true` |
+| `SESSION_COOKIE_HTTPONLY` | Флаг `HttpOnly` для session cookie | `true` |
+| `SESSION_COOKIE_SAMESITE` | Политика `SameSite` для session cookie | `Lax` |
+| `CSRF_COOKIE_SECURE` | Флаг `Secure` для CSRF cookie | `true` |
+| `SECURE_SSL_REDIRECT` | Принудительное перенаправление на HTTPS | `true` |
+| `SECURE_HSTS_SECONDS` | Значение `max-age` для HSTS | `31536000` |
+| `SECURE_HSTS_INCLUDE_SUBDOMAINS` | HSTS для поддоменов | `true` |
+| `SECURE_HSTS_PRELOAD` | Предзагрузка HSTS | `true` |
 | `LANGUAGE_CODE` | Язык интерфейса | `ru-RU` |
 | `TIME_ZONE` | Часовой пояс | `Europe/Moscow` |
 
 ### Дополнительные возможности
 
-- **PostgreSQL**: Для production рекомендуется PostgreSQL вместо SQLite
+- **PostgreSQL**: Для production-развертывания при самостоятельном размещении требуется PostgreSQL вместо SQLite
 - **AI для чеков**: Интеграция с OpenAI API для автоматического распознавания чеков
-- **Error tracking**: Bugsink-compatible мониторинг ошибок в production через `ERROR_TRACKING_DSN`
+- **Мониторинг ошибок**: Sentry-compatible мониторинг ошибок в production через `ERROR_TRACKING_DSN`
+
+### Минимум для production при самостоятельном размещении
+
+Для `docker-compose.prod.yaml` минимальный набор production-переменных включает:
+
+- `SECRET_KEY`
+- `DJANGO_SETTINGS_MODULE=config.django.prod`
+- `DEBUG=false`
+- `ALLOWED_HOSTS`
+- `BASE_URL`
+- `CSRF_TRUSTED_ORIGINS`
+- `REDIS_LOCATION`
+- `POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD` для встроенного PostgreSQL в `docker-compose.prod.yaml`
+- `DATABASE_URL` для внешней PostgreSQL
+- переменные cookie и transport security: `SESSION_COOKIE_SECURE`, `SESSION_COOKIE_HTTPONLY`, `SESSION_COOKIE_SAMESITE`, `CSRF_COOKIE_SECURE`, `SECURE_SSL_REDIRECT`, `SECURE_HSTS_SECONDS`, `SECURE_HSTS_INCLUDE_SUBDOMAINS`, `SECURE_HSTS_PRELOAD`
+- `ERROR_TRACKING_DSN` и `ERROR_TRACKING_ENVIRONMENT` для мониторинга production-окружения
+
+Секреты не должны храниться в репозитории или поддерживаться вручную в локальном `.env` на сервере без контроля изменений. Для production-развертывания при самостоятельном размещении `.env` должен формироваться на этапе деплоя из CI/CD secrets, менеджера секретов или зашифрованной системы управления конфигурацией.
+
+Подробный чек-лист production-развертывания: [docs/docs/production_self_hosted.md](docs/docs/production_self_hosted.md)
 
 #### Redis — Кеширование для производительности
 

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -48,6 +48,7 @@ services:
       - .env
     environment:
       DJANGO_SETTINGS_MODULE: ${DJANGO_SETTINGS_MODULE}
+      DATABASE_URL: ${DATABASE_URL:-postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@db:5432/${POSTGRES_DB:-hlvm}}
     depends_on:
       db:
         condition: service_healthy
@@ -73,6 +74,7 @@ services:
       - .env
     environment:
       DJANGO_SETTINGS_MODULE: ${DJANGO_SETTINGS_MODULE}
+      DATABASE_URL: ${DATABASE_URL:-postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@db:5432/${POSTGRES_DB:-hlvm}}
     depends_on:
       db:
         condition: service_healthy

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -1,51 +1,61 @@
-# Getting started
+# Начало работы
 [![hasta-la-vista-money](https://github.com/TurtleOld/hasta-la-vista-money/actions/workflows/hasta_la_vista_money.yaml/badge.svg)](https://github.com/TurtleOld/hasta-la-vista-money/actions/workflows/hasta_la_vista_money.yaml)  
 
-Welcome to the documentation page of the project **Hasta La Vista, Money**!
+Добро пожаловать в документацию проекта **Hasta La Vista, Money**.
 
-### Disclaimer:
-The Hasta La Vista, Money project is currently under active development, so be aware of potential bugs and future changes.
+### Важно
+
+Проект Hasta La Vista, Money находится в активной разработке, поэтому возможны ошибки и дальнейшие изменения.
 ___
-Hasta La Vista, Money is a home accounting project designed to efficiently manage family expenses and income. Additionally, the app provides an easy way to enter purchase data manually.
+Hasta La Vista, Money - это проект домашней бухгалтерии, предназначенный для удобного учета семейных доходов и расходов. Кроме того, приложение позволяет быстро вносить данные о покупках вручную.
 
 
-The application is deployed on your own hosting using [Docker](https://docs.docker.com/desktop/setup/install/linux/), instructions below.
+Приложение разворачивается на собственной инфраструктуре с использованием [Docker](https://docs.docker.com/desktop/setup/install/linux/). Инструкция приведена ниже.
 
-## Installation  
+## Установка
 
-The application is deployed using [Docker](https://docs.docker.com/desktop/setup/install/linux/). You can deploy it on your local machine or a server.
+Приложение разворачивается с использованием [Docker](https://docs.docker.com/desktop/setup/install/linux/). Развертывание возможно как на локальной машине, так и на сервере.
 ___
 
-In the directory where the project files will reside, create a _.env_ file and populate it with the following details:
+В каталоге, где будут размещены файлы проекта, создайте файл `.env` и заполните его следующими значениями:
 
-SECRET_KEY - Key for the settings.py file. You can generate the key using the command - ```bash
+`SECRET_KEY` - ключ для `settings.py`. Его можно сгенерировать командой:
+
+```bash
 base64 /dev/urandom | head -c50
 ```
 
 > SECRET_KEY=
 
-DEBUG - Debugging activation. Do not enable on a production server.
-Set one of the following values: true, 1, yes.
+`DEBUG` - включает режим отладки. На production-сервере включать не следует.
+Допустимые значения: `true`, `1`, `yes`.
 
 > DEBUG=
 
-DATABASE_URL - Database connection URL  
-postgres://username:password@name or IP server:port/name_database
+`DATABASE_URL` - URL подключения к базе данных.
+
+Пример:
+
+`postgres://username:password@hostname-or-ip:port/database_name`
 
 > DATABASE_URL=
 
-ALLOWED_HOSTS - List of allowed hosts. Example 'localhost',
-'127.0.0.1'. By default, hosts - localhost, 127.0.0.1
+`ALLOWED_HOSTS` - список разрешенных хостов.
+
+Пример: `localhost,127.0.0.1`.
 
 > ALLOWED_HOSTS=  
 
 ___
 
-Download the [docker-compose.yaml](https://github.com/TurtleOld/hasta-la-vista-money/releases/download/v1.4.0/docker-compose.yaml) file and place it in your directory. This file is a sample and serves as a basic template for launching the application. Feel free to modify it as you see fit.
+Скачайте файл [docker-compose.yaml](https://github.com/TurtleOld/hasta-la-vista-money/releases/download/v1.4.0/docker-compose.yaml) и поместите его в рабочий каталог. Этот файл является примером и служит базовым шаблоном для запуска приложения. При необходимости измените его под свою среду.
 
-Next, start the application using the command below:
+Для production-развертывания при самостоятельном размещении используйте отдельный чек-лист и руководство по минимальному набору переменных: [Self-hosted production](production_self_hosted.md).
+
+После этого запустите приложение командой:
 ```bash
 docker compose up -d
 ```
-The application will launch in the background. If there are no errors after running the command, open your browser and go to http://127.0.0.1:8090.  
-Upon the first launch of the website, a registration page will open for creating an administrator account.
+Приложение будет запущено в фоновом режиме. Если после выполнения команды ошибок нет, откройте браузер и перейдите по адресу `http://127.0.0.1:8090`.
+
+При первом запуске сайта откроется страница регистрации для создания учетной записи администратора.

--- a/docs/docs/production_self_hosted.md
+++ b/docs/docs/production_self_hosted.md
@@ -1,0 +1,116 @@
+# Self-hosted production-развертывание
+
+Это руководство описывает минимально необходимое окружение и проверки для
+production-развертывания при самостоятельном размещении.
+
+## Политика работы с секретами
+
+Не храните production-секреты в репозитории.
+
+Не создавайте вручную и не редактируйте на сервере неуправляемый файл `.env`.
+
+Вместо этого используйте один из контролируемых способов:
+
+1. CI/CD secrets формируют runtime-файл `.env` во время деплоя.
+2. Менеджер секретов, например Vault, 1Password Secrets Automation, Doppler
+   или Infisical, формирует runtime-файл `.env` во время деплоя.
+3. Инструмент управления конфигурацией, например Ansible, записывает
+   runtime-файл `.env` из зашифрованных переменных.
+
+Если `docker-compose.prod.yaml` читает `.env`, рассматривайте этот файл как
+сгенерированный runtime-артефакт, а не как вручную поддерживаемый источник
+истинных значений.
+
+## Обязательные переменные окружения
+
+Эти переменные должны быть заданы для каждого production-развертывания при
+самостоятельном размещении:
+
+| Переменная | Обязательность | Примечание |
+|---|---|---|
+| `DJANGO_SETTINGS_MODULE` | Да | Используйте `config.django.prod`. |
+| `SECRET_KEY` | Да | Генерируйте отдельное стойкое значение для каждого развертывания. |
+| `DEBUG` | Да | Должно быть `false`. |
+| `ALLOWED_HOSTS` | Да | Список публичных хостов через запятую, например `money.example.com`. |
+| `BASE_URL` | Да | Публичный HTTPS-адрес с завершающим `/`, например `https://money.example.com/`. |
+| `CSRF_TRUSTED_ORIGINS` | Да | Список доверенных HTTPS origins через запятую, например `https://money.example.com`. |
+| `DATABASE_URL` | Условно | Требуется при использовании внешнего экземпляра PostgreSQL вместо встроенного сервиса `db`. |
+| `REDIS_LOCATION` | Да | URL Redis, используемый в production для кеша, сессий, Celery, rate limiting и axes. |
+| `SESSION_COOKIE_SECURE` | Да | В production сохраняйте значение `true`. |
+| `SESSION_COOKIE_HTTPONLY` | Да | В production сохраняйте значение `true`. |
+| `SESSION_COOKIE_SAMESITE` | Да | Значение по умолчанию `Lax` подходит для текущего приложения. |
+| `CSRF_COOKIE_SECURE` | Да | В production сохраняйте значение `true`. |
+| `SECURE_SSL_REDIRECT` | Да | Сохраняйте `true`, если только TLS не завершается до приложения и это корректно не настроено. |
+| `SECURE_CONTENT_TYPE_NOSNIFF` | Да | Сохраняйте `true`. |
+| `SECURE_HSTS_SECONDS` | Да | Значение по умолчанию `31536000`. Уменьшайте только при осторожном поэтапном включении HSTS. |
+| `SECURE_HSTS_INCLUDE_SUBDOMAINS` | Да | Сохраняйте `true`, если все поддомены готовы к работе только по HTTPS. |
+| `SECURE_HSTS_PRELOAD` | Да | Сохраняйте `true` только если вы намерены выполнить требования preload-списка. |
+| `ERROR_TRACKING_DSN` | Рекомендуется | Sentry-compatible DSN. Настоятельно рекомендуется для диагностики production-сбоев. |
+| `ERROR_TRACKING_ENVIRONMENT` | Рекомендуется | Обычно `production`. |
+
+Следующие переменные обязательны при использовании встроенного Postgres-сервиса
+из `docker-compose.prod.yaml`. В этом режиме `docker compose` автоматически
+формирует `DATABASE_URL` для приложения, поэтому одни и те же учетные данные
+не нужно дублировать одновременно в `DATABASE_URL` и `POSTGRES_*`.
+
+| Переменная | Обязательность | Примечание |
+|---|---|---|
+| `POSTGRES_DB` | Да | Имя базы данных для контейнера Postgres. |
+| `POSTGRES_USER` | Да | Имя пользователя базы данных для контейнера Postgres. |
+| `POSTGRES_PASSWORD` | Да | Пароль базы данных для контейнера Postgres. Секрет. |
+
+## Минимальный пример
+
+```env
+DJANGO_SETTINGS_MODULE=config.django.prod
+SECRET_KEY=replace-with-generated-secret-key
+DEBUG=false
+ALLOWED_HOSTS=money.example.com
+BASE_URL=https://money.example.com/
+CSRF_TRUSTED_ORIGINS=https://money.example.com
+REDIS_LOCATION=redis://redis:6379/0
+POSTGRES_DB=hlvm
+POSTGRES_USER=hlvm
+POSTGRES_PASSWORD=replace-with-db-password
+SESSION_COOKIE_SECURE=true
+SESSION_COOKIE_HTTPONLY=true
+SESSION_COOKIE_SAMESITE=Lax
+CSRF_COOKIE_SECURE=true
+SECURE_SSL_REDIRECT=true
+SECURE_CONTENT_TYPE_NOSNIFF=true
+SECURE_HSTS_SECONDS=31536000
+SECURE_HSTS_INCLUDE_SUBDOMAINS=true
+SECURE_HSTS_PRELOAD=true
+ERROR_TRACKING_DSN=
+ERROR_TRACKING_ENVIRONMENT=production
+```
+
+Для внешнего экземпляра PostgreSQL используйте:
+
+```env
+DATABASE_URL=postgresql://hlvm:replace-with-db-password@db.example.com:5432/hlvm
+```
+
+## Чек-лист production-развертывания
+
+1. Сгенерируйте `SECRET_KEY` вне репозитория и храните его в CI secrets или в менеджере секретов.
+2. Храните `POSTGRES_PASSWORD`, `DATABASE_URL` при его использовании и прочие секреты в CI secrets или в менеджере секретов.
+3. Формируйте runtime-файл `.env` из управляемых секретов во время деплоя.
+4. Убедитесь, что runtime-файл `.env` не закоммичен и имеет ограниченные права доступа на хосте.
+5. Установите `DJANGO_SETTINGS_MODULE=config.django.prod`.
+6. Установите `DEBUG=false`.
+7. Установите `ALLOWED_HOSTS` в список реальных публичных хостов.
+8. Установите `BASE_URL` и `CSRF_TRUSTED_ORIGINS` в соответствии с реальным публичным HTTPS-адресом.
+9. Если используется встроенный сервис Postgres, задайте `POSTGRES_DB`, `POSTGRES_USER` и `POSTGRES_PASSWORD`.
+10. Если используется внешний PostgreSQL, задайте `DATABASE_URL`.
+11. Установите `REDIS_LOCATION` на доступный экземпляр Redis.
+12. Сохраняйте `SESSION_COOKIE_SECURE=true` и `CSRF_COOKIE_SECURE=true`.
+13. Сохраняйте `SESSION_COOKIE_HTTPONLY=true` и отдельно проверьте `SESSION_COOKIE_SAMESITE`, прежде чем менять его.
+14. Сохраняйте `SECURE_SSL_REDIRECT=true`, если только TLS не завершается выше по цепочке и это не проверено отдельно.
+15. Проверьте `SECURE_HSTS_SECONDS`, `SECURE_HSTS_INCLUDE_SUBDOMAINS` и `SECURE_HSTS_PRELOAD` перед публичным запуском.
+16. Настройте `ERROR_TRACKING_DSN` и `ERROR_TRACKING_ENVIRONMENT` для наблюдаемости production-окружения.
+17. Запустите стек командой `docker compose -f docker-compose.prod.yaml up -d`.
+18. Убедитесь, что контейнеры находятся в состоянии health, командой `docker compose -f docker-compose.prod.yaml ps`.
+19. Убедитесь, что приложение доступно по HTTPS, а cookies помечены флагом `Secure`.
+20. Проверьте вход в систему, сохранение сессий, Redis-зависимые операции и подключение к базе данных.
+21. До ввода в эксплуатацию проверьте процедуры резервного копирования и восстановления PostgreSQL и пользовательских файлов.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -4,9 +4,10 @@ edit_uri: edit/main/docs/
 docs_dir: docs
 nav:
   - Hasta la Vista, Money:
-    - Quick start:
-      - Installation: index.md
-      - Registration: registration.md
+    - Быстрый старт:
+      - Установка: index.md
+      - Self-hosted: production_self_hosted.md
+      - Регистрация: registration.md
     - Getting Started:
       - User Management:
         - Users Documentation: users/users_documentation.md


### PR DESCRIPTION
Align the production env example and deployment docs with the real self-hosted minimum while removing duplicated database configuration for the bundled Postgres setup.