### PR TITLE
build(docker): unify receipt inference image naming and tag prefixes

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -31,8 +31,12 @@ jobs:
         image:
           - image_name: ${{ github.repository }}
             dockerfile: docker/production.Dockerfile
-          - image_name: turtleold/hasta-la-vista-money-receipt-inference
+            latest_tag: latest
+            tag_prefix: ""
+          - image_name: ${{ github.repository }}
             dockerfile: receipt_inference/Dockerfile
+            latest_tag: receipt-inference-latest
+            tag_prefix: receipt-inference-
 
     steps:
       - name: Checkout repository
@@ -61,12 +65,12 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ matrix.image.image_name }}
           tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=sha,prefix=sha-,format=short
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=ref,event=branch,prefix=${{ matrix.image.tag_prefix }}
+            type=ref,event=pr,prefix=${{ matrix.image.tag_prefix }}pr-
+            type=semver,pattern=${{ matrix.image.tag_prefix }}{{version}}
+            type=semver,pattern=${{ matrix.image.tag_prefix }}{{major}}.{{minor}}
+            type=sha,prefix=${{ matrix.image.tag_prefix }}sha-,format=short
+            type=raw,value=${{ matrix.image.latest_tag }},enable={{is_default_branch}}
 
       - name: Build and push Docker image
         id: build-and-push

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -89,7 +89,7 @@ services:
     restart: unless-stopped
 
   receipt-inference:
-    image: ghcr.io/turtleold/hasta-la-vista-money-receipt-inference:main
+    image: ghcr.io/turtleold/hasta-la-vista-money:receipt-inference-main
     environment:
       RECEIPT_INFERENCE_HOST: ${RECEIPT_INFERENCE_HOST:-0.0.0.0}
       RECEIPT_INFERENCE_PORT: ${RECEIPT_INFERENCE_PORT:-8010}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -111,6 +111,7 @@ services:
     build:
       context: ./
       dockerfile: receipt_inference/Dockerfile
+    image: ghcr.io/turtleold/hasta-la-vista-money:receipt-inference-main
     environment:
       RECEIPT_INFERENCE_HOST: ${RECEIPT_INFERENCE_HOST:-0.0.0.0}
       RECEIPT_INFERENCE_PORT: ${RECEIPT_INFERENCE_PORT:-8010}


### PR DESCRIPTION
Publish the receipt inference container under the main repository image name with dedicated tag prefixes instead of a separate image path.

Update compose files to reference the new tagged image so local and production deployments resolve the same registry naming scheme.