### PR TITLE
ci(workflow): configure multi-platform Docker builds with matrix stra…

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -33,7 +33,7 @@ jobs:
             dockerfile: docker/production.Dockerfile
             latest_tag: latest
             tag_prefix: ""
-            platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
+            platforms: linux/amd64
           - image_name: ${{ github.repository }}
             dockerfile: receipt_inference/Dockerfile
             latest_tag: receipt-inference-latest

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -33,10 +33,12 @@ jobs:
             dockerfile: docker/production.Dockerfile
             latest_tag: latest
             tag_prefix: ""
+            platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
           - image_name: ${{ github.repository }}
             dockerfile: receipt_inference/Dockerfile
             latest_tag: receipt-inference-latest
             tag_prefix: receipt-inference-
+            platforms: linux/amd64
 
     steps:
       - name: Checkout repository
@@ -83,7 +85,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max,scope=${{ matrix.image.image_name }}
           file: ${{ matrix.image.dockerfile }}
-          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
+          platforms: ${{ matrix.image.platforms }}
 
       - name: Sign the published Docker image
         if: ${{ github.event_name != 'pull_request' }}


### PR DESCRIPTION
…tegy

Define explicit platform configurations for Docker image builds using matrix strategy. Main repository image now builds for both linux/amd64 and linux/arm64 on push events, while receipt-inference image targets linux/amd64 specifically. Pull requests default to linux/amd64 only to reduce CI resource consumption. Centralize platform definitions in matrix configuration for improved maintainability and consistency across build jobs.