### PR TITLE
build: configure nginx for production static and media serving

### DIFF
--- a/config/django/base.py
+++ b/config/django/base.py
@@ -113,7 +113,6 @@ MIDDLEWARE = [
     'corsheaders.middleware.CorsMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.middleware.locale.LocaleMiddleware',
-    'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -125,6 +124,9 @@ MIDDLEWARE = [
     'hasta_la_vista_money.compressor_middleware.CompressorNonceMiddleware',
     'django_structlog.middlewares.RequestMiddleware',
 ]
+
+if not DEBUG:
+    MIDDLEWARE.insert(4, 'whitenoise.middleware.WhiteNoiseMiddleware')
 
 
 if not IS_TESTING:

--- a/config/urls.py
+++ b/config/urls.py
@@ -1,6 +1,11 @@
+import asyncio
+import mimetypes
+from pathlib import Path
+
 from django.conf import settings
-from django.conf.urls.static import static
 from django.contrib import admin
+from django.contrib.staticfiles import finders
+from django.http import Http404, StreamingHttpResponse
 from django.urls import include, path, re_path
 from drf_spectacular.views import (
     SpectacularAPIView,
@@ -12,6 +17,58 @@ from hasta_la_vista_money.users.views import (
     LoginUser,
     LogoutUser,
 )
+
+
+async def _file_iterator(
+    file_path: Path,
+    chunk_size: int = 64 * 1024,
+):
+    file_handle = await asyncio.to_thread(file_path.open, 'rb')
+    try:
+        while True:
+            chunk = await asyncio.to_thread(file_handle.read, chunk_size)
+            if not chunk:
+                break
+            yield chunk
+    finally:
+        await asyncio.to_thread(file_handle.close)
+
+
+async def _serve_file(file_path: Path) -> StreamingHttpResponse:
+    if not file_path.exists() or file_path.is_dir():
+        raise Http404
+
+    content_type, encoding = mimetypes.guess_type(file_path.name)
+    stat_result = await asyncio.to_thread(file_path.stat)
+    response = StreamingHttpResponse(
+        _file_iterator(file_path),
+        content_type=content_type or 'application/octet-stream',
+    )
+    response['Content-Length'] = str(stat_result.st_size)
+    if encoding:
+        response['Content-Encoding'] = encoding
+    return response
+
+
+async def debug_media_serve(request, path: str):
+    del request
+    media_root = Path(settings.MEDIA_ROOT)
+    file_path = (media_root / path).resolve()
+    if (
+        media_root.resolve() not in file_path.parents
+        and file_path != media_root.resolve()
+    ):
+        raise Http404
+    return await _serve_file(file_path)
+
+
+async def debug_static_serve(request, path: str):
+    del request
+    static_file = finders.find(path)
+    if not static_file:
+        raise Http404
+    return await _serve_file(Path(static_file))
+
 
 urlpatterns = [
     re_path(
@@ -103,4 +160,7 @@ if settings.DEBUG:
     urlpatterns += [
         path('__reload__/', include('django_browser_reload.urls')),
     ]
-    urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+    urlpatterns += [
+        re_path(r'^media/(?P<path>.*)$', debug_media_serve),
+        re_path(r'^static/(?P<path>.*)$', debug_static_serve),
+    ]

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -42,6 +42,7 @@ services:
     volumes:
       - staticfiles_data:/app/staticfiles
       - media_data:/app/media
+      - nginx_config_data:/app/nginx-runtime
     ports:
       - "8001:8001"
     env_file:
@@ -145,11 +146,15 @@ services:
 
   nginx:
     image: nginx:1.30.0-alpine
+    command:
+      - /bin/sh
+      - -c
+      - while [ ! -f /app/nginx/nginx.conf ]; do sleep 1; done; exec nginx -g 'daemon off;' -c /app/nginx/nginx.conf
     ports:
       - "80:80"
       - "443:443"
     volumes:
-      - ${CONF_PATH:-./nginx}/nginx.conf:/etc/nginx/nginx.conf
+      - nginx_config_data:/app/nginx:ro
       - staticfiles_data:/app/staticfiles
       - media_data:/app/media
     depends_on:
@@ -163,6 +168,7 @@ volumes:
   staticfiles_data:
   redis_data:
   media_data:
+  nginx_config_data:
 
 networks:
   default:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -17,6 +17,13 @@ echo "Creating staticfiles, media and logs directories with proper permissions"
 mkdir -p /app/staticfiles /app/media /app/logs
 chmod -R 755 /app/staticfiles /app/media /app/logs
 
+if [ -d /app/nginx-runtime ] && [ -f /app/nginx/nginx.conf ]; then
+    echo "Copying nginx configuration to shared volume"
+    mkdir -p /app/nginx-runtime
+    cp /app/nginx/nginx.conf /app/nginx-runtime/nginx.conf
+    chmod 644 /app/nginx-runtime/nginx.conf
+fi
+
 echo "Collecting static files"
 python manage.py collectstatic --noinput --clear
 

--- a/docker/production.Dockerfile
+++ b/docker/production.Dockerfile
@@ -47,6 +47,7 @@ COPY hasta_la_vista_money/ ./hasta_la_vista_money/
 COPY locale/ ./locale/
 COPY theme/ ./theme/
 COPY static/ ./static/
+COPY nginx/ ./nginx/
 COPY docker/entrypoint.sh docker/celery-entrypoint.sh ./docker/
 
 COPY --from=node-builder /app/static/css/styles.min.css ./static/css/styles.min.css
@@ -80,14 +81,15 @@ COPY --from=builder --chown=appuser:appuser /app/hasta_la_vista_money /app/hasta
 COPY --from=builder --chown=appuser:appuser /app/locale /app/locale
 COPY --from=builder --chown=appuser:appuser /app/theme /app/theme
 COPY --from=builder --chown=appuser:appuser /app/static /app/static
+COPY --from=builder --chown=appuser:appuser /app/nginx /app/nginx
 COPY --from=builder /app/docker/entrypoint.sh /app/entrypoint.sh
 COPY --from=builder /app/docker/celery-entrypoint.sh /app/celery-entrypoint.sh
 
 RUN sed -i 's/\r$//' /app/entrypoint.sh /app/celery-entrypoint.sh && \
     chmod +x /app/entrypoint.sh /app/celery-entrypoint.sh && \
-    mkdir -p /app/staticfiles /app/media /app/logs && \
-    chown -R appuser:appuser /app/staticfiles /app/media /app/logs && \
-    chmod -R 755 /app/staticfiles /app/media /app/logs
+    mkdir -p /app/staticfiles /app/media /app/logs /app/nginx-runtime && \
+    chown -R appuser:appuser /app/staticfiles /app/media /app/logs /app/nginx-runtime && \
+    chmod -R 755 /app/staticfiles /app/media /app/logs /app/nginx-runtime
 
 USER appuser
 


### PR DESCRIPTION
Refactor Django middleware to conditionally include WhiteNoiseMiddleware only in non-debug mode.

Implement async file serving for media and static files in debug mode, replacing static() URL patterns.

Update docker-compose.prod.yaml to use shared volume for nginx config, add wait command for nginx.conf availability, and mount nginx_config_data volume.

Modify entrypoint.sh to copy nginx.conf to shared volume when present.

Update production.Dockerfile to copy nginx directory and create nginx-runtime directory with proper permissions.