### PR TITLE
feat(receipt-inference): enable configurable model alias for llama server and improve error handling

### DIFF
--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -136,6 +136,8 @@ services:
       - ${LLAMA_CONTEXT_SIZE:-8192}
       - -np
       - ${LLAMA_PARALLEL:-1}
+      - --alias
+      - ${LLAMA_MODEL_ALIAS:-Qwen2.5-3B-Instruct-Q5_K_M}
     volumes:
       - ${RECEIPT_INFERENCE_MODELS_PATH:-/opt/docker/hlvm/receipt-inference/models}:/models:ro
     networks:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -156,6 +156,8 @@ services:
       - ${LLAMA_CONTEXT_SIZE:-8192}
       - -np
       - ${LLAMA_PARALLEL:-1}
+      - --alias
+      - ${LLAMA_MODEL_ALIAS:-Qwen2.5-3B-Instruct-Q5_K_M}
     volumes:
       - ${RECEIPT_INFERENCE_MODELS_PATH:-./models/receipt-inference}:/models:ro
     ports:

--- a/receipt_inference/src/receipt_inference/pipeline.py
+++ b/receipt_inference/src/receipt_inference/pipeline.py
@@ -22,7 +22,6 @@ if TYPE_CHECKING:
 
 logger = structlog.get_logger(__name__)
 
-QWEN_MODEL_NAME = 'Qwen2.5-3B-Instruct-Q5_K_M'
 MIN_OCR_ENTRY_PARTS = 2
 JSON_BLOCK_PATTERN = re.compile(
     r'```(?:json)?\s*(\{.*?\})\s*```',
@@ -321,7 +320,7 @@ class LlamaServerBackend:
         """Send OCR text to llama-server and return raw model output."""
         messages = self._prompt_builder.build_messages(ocr_result.text)
         payload = {
-            'model': QWEN_MODEL_NAME,
+            'model': self._model_alias,
             'temperature': 0,
             'messages': messages,
         }
@@ -351,6 +350,18 @@ class LlamaServerBackend:
                 status_code=504,
             ) from exc
         except httpx.HTTPError as exc:
+            response = getattr(exc, 'response', None)
+            logger.warning(
+                'receipt_inference_llm_request_failed',
+                error_type=type(exc).__name__,
+                error=str(exc),
+                status_code=(
+                    response.status_code if response is not None else None
+                ),
+                response_text=(
+                    response.text[:1000] if response is not None else None
+                ),
+            )
             raise ReceiptInferenceError(
                 error_code='llm_unavailable',
                 message='Llama server is unavailable for receipt parsing.',


### PR DESCRIPTION
Add --alias flag to llama-server in docker-compose files for dynamic model naming, remove hardcoded QWEN_MODEL_NAME constant in pipeline.py, and enhance HTTP error logging with status code and response details.