### PR TITLE
perf(receipt-inference): optimize inference with increased threads, resources, and warmup

### DIFF
--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -96,8 +96,8 @@ services:
       RECEIPT_INFERENCE_PORT: ${RECEIPT_INFERENCE_PORT:-8010}
       RECEIPT_INFERENCE_LOG_LEVEL: ${RECEIPT_INFERENCE_LOG_LEVEL:-info}
       RECEIPT_INFERENCE_MAX_CONCURRENCY: ${RECEIPT_INFERENCE_MAX_CONCURRENCY:-1}
-      LLAMA_THREADS: ${LLAMA_THREADS:-2}
-      OCR_THREADS: ${OCR_THREADS:-1}
+      LLAMA_THREADS: ${LLAMA_THREADS:-4}
+      OCR_THREADS: ${OCR_THREADS:-2}
       LLAMA_SERVER_URL: ${LLAMA_SERVER_URL:-http://receipt-llm:8080/v1}
       LLAMA_TIMEOUT: ${LLAMA_TIMEOUT:-300}
       LLAMA_MAX_TOKENS: ${LLAMA_MAX_TOKENS:-768}
@@ -118,8 +118,8 @@ services:
       timeout: 10s
       retries: 3
       start_period: 120s
-    cpus: 1.5
-    mem_limit: 4g
+    cpus: 2.0
+    mem_limit: 6g
     restart: unless-stopped
 
   receipt-llm:
@@ -128,7 +128,7 @@ services:
       - -m
       - ${QWEN_MODEL_PATH:-/models/qwen/qwen2.5-3b-instruct-q5_k_m.gguf}
       - -t
-      - ${LLAMA_THREADS:-2}
+      - ${LLAMA_THREADS:-4}
       - --host
       - 0.0.0.0
       - --port
@@ -149,8 +149,8 @@ services:
       timeout: 10s
       retries: 5
       start_period: 120s
-    cpus: 1.5
-    mem_limit: 4g
+    cpus: 3.0
+    mem_limit: 8g
     restart: unless-stopped
 
   nginx:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -117,8 +117,8 @@ services:
       RECEIPT_INFERENCE_PORT: ${RECEIPT_INFERENCE_PORT:-8010}
       RECEIPT_INFERENCE_LOG_LEVEL: ${RECEIPT_INFERENCE_LOG_LEVEL:-debug}
       RECEIPT_INFERENCE_MAX_CONCURRENCY: ${RECEIPT_INFERENCE_MAX_CONCURRENCY:-1}
-      LLAMA_THREADS: ${LLAMA_THREADS:-2}
-      OCR_THREADS: ${OCR_THREADS:-1}
+      LLAMA_THREADS: ${LLAMA_THREADS:-4}
+      OCR_THREADS: ${OCR_THREADS:-2}
       LLAMA_SERVER_URL: ${LLAMA_SERVER_URL:-http://receipt-llm:8080/v1}
       LLAMA_TIMEOUT: ${LLAMA_TIMEOUT:-300}
       LLAMA_MAX_TOKENS: ${LLAMA_MAX_TOKENS:-768}
@@ -149,7 +149,7 @@ services:
       - -m
       - ${QWEN_MODEL_PATH:-/models/qwen/qwen2.5-3b-instruct-q5_k_m.gguf}
       - -t
-      - ${LLAMA_THREADS:-2}
+      - ${LLAMA_THREADS:-4}
       - --host
       - 0.0.0.0
       - --port

--- a/receipt_inference/src/receipt_inference/app.py
+++ b/receipt_inference/src/receipt_inference/app.py
@@ -53,15 +53,29 @@ def _serialize_settings(settings: ReceiptInferenceSettings) -> dict[str, Any]:
 
 @asynccontextmanager
 async def lifespan(app: Starlette) -> AsyncIterator[None]:
-    """Load static configuration and perform lightweight startup checks."""
+    """Load configuration and warm up runtime dependencies."""
     settings = load_settings()
     service = ReceiptInferenceService(settings)
+    warmup_started_at = perf_counter()
+
+    try:
+        service.warmup()
+    except ReceiptInferenceError:
+        if settings.ocr_readiness_required:
+            raise
+        logger.warning(
+            'receipt_inference_warmup_skipped',
+            reason='ocr_readiness_not_required',
+            exc_info=True,
+        )
+
     app.state.settings = settings
     app.state.service = service
     logger.info(
         'receipt_inference_startup',
         settings=_serialize_settings(settings),
         readiness=service.readiness_status(),
+        warmup_ms=round((perf_counter() - warmup_started_at) * 1000, 2),
     )
     yield
 

--- a/receipt_inference/src/receipt_inference/config.py
+++ b/receipt_inference/src/receipt_inference/config.py
@@ -43,8 +43,8 @@ def load_settings() -> ReceiptInferenceSettings:
         max_concurrency=int(
             os.getenv('RECEIPT_INFERENCE_MAX_CONCURRENCY', '1'),
         ),
-        llama_threads=int(os.getenv('LLAMA_THREADS', '2')),
-        ocr_threads=int(os.getenv('OCR_THREADS', '1')),
+        llama_threads=int(os.getenv('LLAMA_THREADS', '4')),
+        ocr_threads=int(os.getenv('OCR_THREADS', '2')),
         llama_server_url=os.getenv(
             'LLAMA_SERVER_URL',
             'http://127.0.0.1:8080/v1',

--- a/receipt_inference/src/receipt_inference/pipeline.py
+++ b/receipt_inference/src/receipt_inference/pipeline.py
@@ -127,6 +127,10 @@ class PaddleOCRBackend:
             return False
         return True
 
+    def warmup(self) -> None:
+        """Load the OCR model ahead of the first real receipt request."""
+        self._get_ocr_instance()
+
     def extract(self, prepared_image: PreparedImage) -> OCRResult:
         """Extract ordered text lines from the prepared receipt image."""
         ocr = self._get_ocr_instance()
@@ -156,7 +160,7 @@ class PaddleOCRBackend:
         return OCRResult(text=text, line_count=len(filtered_lines))
 
     def _get_ocr_instance(self) -> Any:
-        """Create PaddleOCR lazily so startup stays lightweight."""
+        """Create PaddleOCR lazily and reuse it across requests."""
         if self._ocr_instance is not None:
             return self._ocr_instance
 
@@ -573,6 +577,10 @@ class ReceiptInferencePipeline:
                 else True
             ),
         }
+
+    def warmup(self) -> None:
+        """Warm up heavy runtime dependencies during service startup."""
+        self._ocr_backend.warmup()
 
     def preprocess(self, image_bytes: bytes) -> PreparedImage:
         """Preprocess image bytes before OCR."""

--- a/receipt_inference/src/receipt_inference/service.py
+++ b/receipt_inference/src/receipt_inference/service.py
@@ -50,6 +50,10 @@ class ReceiptInferenceService:
         """Return dependency readiness for health endpoints."""
         return self._pipeline.readiness_status()
 
+    def warmup(self) -> None:
+        """Warm up heavy inference dependencies at startup."""
+        self._pipeline.warmup()
+
     async def parse_upload(
         self,
         uploaded_file: UploadFile | None,


### PR DESCRIPTION
Increase default LLAMA_THREADS from 2 to 4 and OCR_THREADS from 1 to 2 across docker-compose files and config. Boost CPU and memory limits for receipt-inference (cpus: 1.5->2.0, mem: 4g->6g) and receipt-llm (cpus: 1.5->3.0, mem: 4g->8g) services. Add warmup methods to preload OCR model at startup for faster first requests and improved reliability.