### PR TITLE
feat(receipts): add receipt deletion service with account refund

### DIFF
--- a/hasta_la_vista_money/receipts/containers.py
+++ b/hasta_la_vista_money/receipts/containers.py
@@ -3,6 +3,7 @@ from dependency_injector import containers, providers
 from hasta_la_vista_money.receipts.protocols.services import (
     PendingReceiptServiceProtocol,
     ReceiptCreatorServiceProtocol,
+    ReceiptDeleterServiceProtocol,
     ReceiptImportServiceProtocol,
     ReceiptUpdaterServiceProtocol,
 )
@@ -16,6 +17,9 @@ from hasta_la_vista_money.receipts.services.pending_receipt_service import (
 )
 from hasta_la_vista_money.receipts.services.receipt_creator import (
     ReceiptCreatorService,
+)
+from hasta_la_vista_money.receipts.services.receipt_deleter import (
+    ReceiptDeleterService,
 )
 from hasta_la_vista_money.receipts.services.receipt_import import (
     ReceiptImportService,
@@ -59,6 +63,12 @@ class ReceiptsContainer(containers.DeclarativeContainer):
         product_repository=product_repository,
         receipt_repository=receipt_repository,
         seller_repository=seller_repository,
+    )
+    receipt_deleter_service: providers.Factory[
+        ReceiptDeleterServiceProtocol
+    ] = providers.Factory(
+        ReceiptDeleterService,
+        account_service=core.account_service,
     )
     pending_receipt_service: providers.Factory[
         PendingReceiptServiceProtocol

--- a/hasta_la_vista_money/receipts/protocols/services.py
+++ b/hasta_la_vista_money/receipts/protocols/services.py
@@ -71,6 +71,13 @@ class ReceiptUpdaterServiceProtocol(Protocol):
 
 
 @runtime_checkable
+class ReceiptDeleterServiceProtocol(Protocol):
+    """Protocol for receipt deletion service interface."""
+
+    def delete_receipt(self, *, user: User, receipt: Receipt) -> None: ...
+
+
+@runtime_checkable
 class ReceiptImportServiceProtocol(Protocol):
     """Protocol for receipt import service interface.
 

--- a/hasta_la_vista_money/receipts/services/receipt_deleter.py
+++ b/hasta_la_vista_money/receipts/services/receipt_deleter.py
@@ -1,0 +1,31 @@
+from django.db import transaction
+
+from core.protocols.services import AccountServiceProtocol
+from hasta_la_vista_money.receipts.models import Receipt
+from hasta_la_vista_money.users.models import User
+from hasta_la_vista_money.users.services.cache import (
+    invalidate_user_detailed_statistics_cache,
+)
+
+
+class ReceiptDeleterService:
+    """Service for deleting receipts and refunding account balance."""
+
+    def __init__(self, account_service: AccountServiceProtocol) -> None:
+        self.account_service = account_service
+
+    @transaction.atomic
+    def delete_receipt(self, *, user: User, receipt: Receipt) -> None:
+        """Delete receipt and refund its total through BalanceService."""
+        self.account_service.refund_to_account(
+            receipt.account,
+            receipt.total_sum,
+        )
+
+        for product in receipt.product.all():
+            product.delete()
+
+        receipt.delete()
+        transaction.on_commit(
+            lambda: invalidate_user_detailed_statistics_cache(user.pk),
+        )

--- a/hasta_la_vista_money/receipts/tests/test_views_models_apis.py
+++ b/hasta_la_vista_money/receipts/tests/test_views_models_apis.py
@@ -104,9 +104,18 @@ class TestReceipt(TestCase):
 
     def test_receipt_delete(self) -> None:
         self.client.force_login(self.user)
+        initial_balance = self.account.balance
+        receipt_total_sum = self.receipt.total_sum
         url = reverse_lazy('receipts:delete', kwargs={'pk': self.receipt.pk})
         response = self.client.post(url)
         self.assertEqual(response.status_code, constants.REDIRECTS)
+        self.assertFalse(Receipt.objects.filter(pk=self.receipt.pk).exists())
+
+        self.account.refresh_from_db()
+        self.assertEqual(
+            self.account.balance,
+            initial_balance + receipt_total_sum,
+        )
 
     def test_receipt_list_unauthorized(self) -> None:
         response = self.client.get(reverse_lazy('receipts:list'))

--- a/hasta_la_vista_money/receipts/views.py
+++ b/hasta_la_vista_money/receipts/views.py
@@ -61,9 +61,6 @@ from hasta_la_vista_money.receipts.services.pending_receipt_service import (
 )
 from hasta_la_vista_money.receipts.tasks import process_pending_receipt
 from hasta_la_vista_money.users.models import User
-from hasta_la_vista_money.users.services.cache import (
-    invalidate_user_detailed_statistics_cache,
-)
 
 logger = structlog.get_logger(__name__)
 _INSUFFICIENT_FUNDS_CODE = 'insufficient_funds'
@@ -530,57 +527,6 @@ class ReceiptUpdateView(
 
         return self.render_to_response(context)
 
-    def update_account_balance(
-        self,
-        old_account: Account,
-        new_account: Account,
-        old_total_sum: Decimal,
-        new_total_sum: Decimal,
-    ) -> None:
-        """
-        Обновляет баланс счёта при изменении суммы чека.
-
-        Логика:
-        1. Если счёт не изменился:
-           - Вычисляем разницу между старой и новой суммой
-           - Если сумма увеличилась → уменьшаем баланс на разницу
-           - Если сумма уменьшилась → увеличиваем баланс на разницу
-        2. Если счёт изменился:
-           - Возвращаем старую сумму на старый счёт
-           - Списываем новую сумму с нового счёта
-        """
-
-        # Примечание: проверку владельца счёта опускаем, так как доступ к чеку
-        # и валидные queryset'ы аккаунтов уже ограничивают пользователя выше.
-
-        request = cast('RequestWithContainer', self.request)
-        account_repository = (
-            request.container.finance_account.account_repository()
-        )
-        try:
-            old_account_obj = account_repository.get_by_id(old_account.pk)
-            new_account_obj = account_repository.get_by_id(new_account.pk)
-
-            if old_account.pk == new_account.pk:
-                difference = new_total_sum - old_total_sum
-                if difference > 0:
-                    old_account_obj.balance -= difference
-                else:
-                    old_account_obj.balance += abs(difference)
-                old_account_obj.save()
-            else:
-                old_account_obj.balance += old_total_sum
-                old_account_obj.save()
-
-                new_account_obj.balance -= new_total_sum
-                new_account_obj.save()
-
-        except Account.DoesNotExist:
-            logger.exception(
-                'Account not found during receipt update',
-                error=str(self.request.user),
-            )
-
 
 class ReceiptDetailView(
     LoginRequiredMixin,
@@ -636,25 +582,21 @@ class ReceiptDeleteView(
         **kwargs: object,
     ) -> HttpResponse:
         receipt = self.get_object()
-        account = receipt.account
-        amount = receipt.total_sum
-        account_balance = get_object_or_404(Account, pk=account.pk)
+        request_with_container = cast('RequestWithContainer', request)
+        receipt_deleter_service = (
+            request_with_container.container.receipts.receipt_deleter_service()
+        )
 
         try:
-            if account_balance.user == self.request.user:
-                account_balance.balance += amount
-                account_balance.save()
-
-                for product in receipt.product.all():
-                    product.delete()
-
-                receipt.delete()
-                invalidate_user_detailed_statistics_cache(self.request.user.pk)
-                messages.success(
-                    self.request,
-                    constants.SUCCESS_MESSAGE_DELETE_RECEIPT,
-                )
-                return redirect(str(self.success_url))
+            receipt_deleter_service.delete_receipt(
+                user=cast('User', self.request.user),
+                receipt=receipt,
+            )
+            messages.success(
+                self.request,
+                constants.SUCCESS_MESSAGE_DELETE_RECEIPT,
+            )
+            return redirect(str(self.success_url))
         except ProtectedError:
             messages.error(
                 self.request,


### PR DESCRIPTION
Add ReceiptDeleterService to handle receipt deletion with automatic account balance refund. The service encapsulates the logic for deleting receipts, refunding their total sum to the associated account, removing associated products, and invalidating user statistics cache.

Refactor ReceiptDeleteView to use the new service instead of inline deletion logic. Update dependency injection container to register the new service. Add protocol interface for the deletion service.

Tests verify that deleting a receipt correctly refunds the account balance by the receipt's total sum.