### PR TITLE
feat(receipts): validate parsed receipt payloads

### DIFF
--- a/hasta_la_vista_money/receipts/tasks.py
+++ b/hasta_la_vista_money/receipts/tasks.py
@@ -30,6 +30,9 @@ from hasta_la_vista_money.receipts.services.receipt_ai_prompt import (
     ModelUnavailableError,
     RateLimitExceededError,
 )
+from hasta_la_vista_money.receipts.validators.parsed_receipt import (
+    validate_receipt_parse_payload,
+)
 
 logger = structlog.get_logger(__name__)
 
@@ -82,7 +85,10 @@ def _parse_inference_payload(raw: str) -> dict[str, Any]:
         raise ValueError('Empty inference response')
     match = _JSON_CODE_BLOCK_RE.search(raw)
     cleaned = match.group(1) if match else raw.strip()
-    return json.loads(cleaned)
+    payload = json.loads(cleaned)
+    if not isinstance(payload, dict):
+        raise ValueError('Inference response must be a JSON object')
+    return validate_receipt_parse_payload(payload).to_dict()
 
 
 def _run_inference(pending: PendingReceipt) -> dict[str, Any]:

--- a/hasta_la_vista_money/receipts/tests/test_pending_receipt_flow.py
+++ b/hasta_la_vista_money/receipts/tests/test_pending_receipt_flow.py
@@ -35,6 +35,10 @@ from hasta_la_vista_money.receipts.tasks import (
     cleanup_stale_pending_receipts,
     process_pending_receipt,
 )
+from hasta_la_vista_money.receipts.validators.parsed_receipt import (
+    ReceiptParseValidationError,
+    validate_receipt_parse_payload,
+)
 from hasta_la_vista_money.users.models import User
 
 
@@ -195,6 +199,20 @@ class ProcessPendingReceiptTaskTests(TestCase):
         self.assertEqual(pending.status, PendingReceiptStatus.FAILED)
         self.assertNotEqual(pending.error_message, '')
 
+    def test_task_marks_failed_on_invalid_schema(self) -> None:
+        pending = self._create_pending()
+        payload = _fake_payload()
+        payload['items'][0]['price'] = -1
+        with mock.patch(
+            'hasta_la_vista_money.receipts.tasks.analyze_image_with_ai',
+            return_value=json.dumps(payload),
+        ):
+            process_pending_receipt(pending.pk)
+
+        pending.refresh_from_db()
+        self.assertEqual(pending.status, PendingReceiptStatus.FAILED)
+        self.assertNotEqual(pending.error_message, '')
+
     def test_cleanup_purges_expired_rows(self) -> None:
         pending = self._create_pending()
         PendingReceipt.objects.filter(pk=pending.pk).update(
@@ -294,6 +312,40 @@ class ReceiptInferenceClientContentTypeTests(TestCase):
 
         self.assertEqual(json.loads(raw)['name_seller'], 'Shop')
         self.assertEqual(post_calls[0]['files']['file'][2], 'image/png')
+
+
+class ReceiptParseValidatorTests(TestCase):
+    """Receipt-inference payload validation."""
+
+    def test_valid_payload_is_normalized(self) -> None:
+        result = validate_receipt_parse_payload(_fake_payload())
+
+        normalized = result.to_dict()
+
+        self.assertEqual(normalized['total_sum'], '100.00')
+        self.assertEqual(normalized['operation_type'], 1)
+        self.assertEqual(normalized['items'][0]['amount'], '100.00')
+
+    def test_rejects_missing_required_field(self) -> None:
+        payload = _fake_payload()
+        del payload['receipt_date']
+
+        with self.assertRaises(ReceiptParseValidationError):
+            validate_receipt_parse_payload(payload)
+
+    def test_rejects_unknown_fields(self) -> None:
+        payload = _fake_payload()
+        payload['debug_prompt'] = 'leak'
+
+        with self.assertRaises(ReceiptParseValidationError):
+            validate_receipt_parse_payload(payload)
+
+    def test_rejects_total_sum_mismatch(self) -> None:
+        payload = _fake_payload()
+        payload['total_sum'] = '150.00'
+
+        with self.assertRaises(ReceiptParseValidationError):
+            validate_receipt_parse_payload(payload)
 
 
 class UploadImageViewTests(TestCase):

--- a/hasta_la_vista_money/receipts/validators/__init__.py
+++ b/hasta_la_vista_money/receipts/validators/__init__.py
@@ -1,7 +1,19 @@
 """Validators for receipts API."""
 
+from hasta_la_vista_money.receipts.validators.parsed_receipt import (
+    RECEIPT_PARSE_SCHEMA,
+    ReceiptParseResult,
+    ReceiptParseValidationError,
+    validate_receipt_parse_payload,
+)
 from hasta_la_vista_money.receipts.validators.receipt_api_validator import (
     ReceiptAPIValidator,
 )
 
-__all__ = ['ReceiptAPIValidator']
+__all__ = [
+    'RECEIPT_PARSE_SCHEMA',
+    'ReceiptAPIValidator',
+    'ReceiptParseResult',
+    'ReceiptParseValidationError',
+    'validate_receipt_parse_payload',
+]

--- a/hasta_la_vista_money/receipts/validators/parsed_receipt.py
+++ b/hasta_la_vista_money/receipts/validators/parsed_receipt.py
@@ -1,0 +1,377 @@
+"""Validation for parsed receipt payloads from receipt-inference."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from decimal import Decimal, InvalidOperation
+from typing import Any, Final
+
+
+class ReceiptParseValidationError(ValueError):
+    """Raised when receipt-inference returns an invalid receipt payload."""
+
+
+TOP_LEVEL_FIELDS: Final[frozenset[str]] = frozenset(
+    {
+        'name_seller',
+        'retail_place_address',
+        'retail_place',
+        'total_sum',
+        'operation_type',
+        'receipt_date',
+        'number_receipt',
+        'nds10',
+        'nds20',
+        'items',
+    },
+)
+REQUIRED_TOP_LEVEL_FIELDS: Final[frozenset[str]] = frozenset(
+    {
+        'name_seller',
+        'total_sum',
+        'operation_type',
+        'receipt_date',
+        'items',
+    },
+)
+ITEM_FIELDS: Final[frozenset[str]] = frozenset(
+    {'product_name', 'category', 'price', 'quantity', 'amount'},
+)
+REQUIRED_ITEM_FIELDS: Final[frozenset[str]] = frozenset(
+    {'product_name', 'price', 'quantity', 'amount'},
+)
+ALLOWED_OPERATION_TYPES: Final[frozenset[int]] = frozenset({1, 2, 3, 4})
+TOTAL_SUM_TOLERANCE_RATIO: Final[Decimal] = Decimal('0.02')
+TOTAL_SUM_TOLERANCE_MIN: Final[Decimal] = Decimal('1.00')
+
+RECEIPT_PARSE_SCHEMA: Final[dict[str, Any]] = {
+    'type': 'object',
+    'additionalProperties': False,
+    'required': sorted(REQUIRED_TOP_LEVEL_FIELDS),
+    'properties': {
+        'name_seller': {'type': 'string', 'minLength': 1},
+        'retail_place_address': {'type': ['string', 'null']},
+        'retail_place': {'type': ['string', 'null']},
+        'total_sum': {'type': ['number', 'string'], 'exclusiveMinimum': 0},
+        'operation_type': {'type': ['integer', 'string'], 'enum': [1, 2, 3, 4]},
+        'receipt_date': {
+            'type': 'string',
+            'description': 'DD.MM.YYYY HH:MM or short-year equivalent',
+        },
+        'number_receipt': {'type': ['integer', 'string', 'null']},
+        'nds10': {'type': ['number', 'string', 'null'], 'minimum': 0},
+        'nds20': {'type': ['number', 'string', 'null'], 'minimum': 0},
+        'items': {
+            'type': 'array',
+            'minItems': 1,
+            'items': {
+                'type': 'object',
+                'additionalProperties': False,
+                'required': sorted(REQUIRED_ITEM_FIELDS),
+                'properties': {
+                    'product_name': {'type': 'string', 'minLength': 1},
+                    'category': {'type': 'string'},
+                    'price': {'type': ['number', 'string'], 'minimum': 0},
+                    'quantity': {
+                        'type': ['number', 'string'],
+                        'exclusiveMinimum': 0,
+                    },
+                    'amount': {'type': ['number', 'string'], 'minimum': 0},
+                },
+            },
+        },
+    },
+}
+
+
+@dataclass(frozen=True)
+class ReceiptParseItem:
+    """Normalized receipt line item accepted by the review flow."""
+
+    product_name: str
+    category: str
+    price: Decimal
+    quantity: Decimal
+    amount: Decimal
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return JSON-serializable item data."""
+        return {
+            'product_name': self.product_name,
+            'category': self.category,
+            'price': _format_decimal(self.price),
+            'quantity': _format_decimal(self.quantity),
+            'amount': _format_decimal(self.amount),
+        }
+
+
+@dataclass(frozen=True)
+class ReceiptParseResult:
+    """Normalized receipt payload accepted by PendingReceiptService."""
+
+    name_seller: str
+    total_sum: Decimal
+    operation_type: int
+    receipt_date: str
+    items: tuple[ReceiptParseItem, ...]
+    retail_place_address: str | None = None
+    retail_place: str | None = None
+    number_receipt: int | None = None
+    nds10: Decimal | None = None
+    nds20: Decimal | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return JSON-serializable receipt data for JSONField storage."""
+        return {
+            'name_seller': self.name_seller,
+            'retail_place_address': self.retail_place_address,
+            'retail_place': self.retail_place,
+            'total_sum': _format_decimal(self.total_sum),
+            'operation_type': self.operation_type,
+            'receipt_date': self.receipt_date,
+            'number_receipt': self.number_receipt,
+            'nds10': _format_optional_decimal(self.nds10),
+            'nds20': _format_optional_decimal(self.nds20),
+            'items': [item.to_dict() for item in self.items],
+        }
+
+
+def validate_receipt_parse_payload(
+    payload: dict[str, Any],
+) -> ReceiptParseResult:
+    """Validate and normalize receipt-inference payload.
+
+    The local inference service already normalizes most values, but this
+    pre-flight validation is the Django-side contract before ``mark_ready``.
+    """
+    _validate_object_keys(payload, TOP_LEVEL_FIELDS, 'receipt')
+    _validate_required_fields(payload, REQUIRED_TOP_LEVEL_FIELDS, 'receipt')
+
+    items_raw = payload.get('items')
+    if not isinstance(items_raw, list) or not items_raw:
+        raise ReceiptParseValidationError(
+            'receipt.items must be a non-empty list',
+        )
+
+    items = tuple(
+        _validate_item(item, index=index)
+        for index, item in enumerate(items_raw, start=1)
+    )
+    total_sum = _parse_decimal(payload.get('total_sum'), 'receipt.total_sum')
+    if total_sum <= 0:
+        raise ReceiptParseValidationError('receipt.total_sum must be positive')
+
+    _validate_items_total(total_sum, items)
+
+    operation_type = _parse_int(
+        payload.get('operation_type'),
+        'receipt.operation_type',
+    )
+    if operation_type not in ALLOWED_OPERATION_TYPES:
+        raise ReceiptParseValidationError(
+            'receipt.operation_type must be one of 1, 2, 3, 4',
+        )
+
+    receipt_date = _parse_receipt_date(payload.get('receipt_date'))
+    return ReceiptParseResult(
+        name_seller=_parse_required_text(
+            payload.get('name_seller'),
+            'receipt.name_seller',
+        ),
+        retail_place_address=_parse_optional_text(
+            payload.get('retail_place_address'),
+        ),
+        retail_place=_parse_optional_text(payload.get('retail_place')),
+        total_sum=total_sum,
+        operation_type=operation_type,
+        receipt_date=receipt_date,
+        number_receipt=_parse_optional_int(
+            payload.get('number_receipt'),
+            'receipt.number_receipt',
+        ),
+        nds10=_parse_optional_non_negative_decimal(
+            payload.get('nds10'),
+            'receipt.nds10',
+        ),
+        nds20=_parse_optional_non_negative_decimal(
+            payload.get('nds20'),
+            'receipt.nds20',
+        ),
+        items=items,
+    )
+
+
+def _validate_item(value: Any, *, index: int) -> ReceiptParseItem:
+    if not isinstance(value, dict):
+        message = f'receipt.items[{index}] must be an object'
+        raise ReceiptParseValidationError(
+            message,
+        )
+    path = f'receipt.items[{index}]'
+    _validate_object_keys(value, ITEM_FIELDS, path)
+    _validate_required_fields(value, REQUIRED_ITEM_FIELDS, path)
+
+    price = _parse_decimal(value.get('price'), f'{path}.price')
+    quantity = _parse_decimal(value.get('quantity'), f'{path}.quantity')
+    amount = _parse_decimal(value.get('amount'), f'{path}.amount')
+    if price < 0:
+        message = f'{path}.price must not be negative'
+        raise ReceiptParseValidationError(message)
+    if quantity <= 0:
+        message = f'{path}.quantity must be positive'
+        raise ReceiptParseValidationError(message)
+    if amount < 0:
+        message = f'{path}.amount must not be negative'
+        raise ReceiptParseValidationError(message)
+
+    return ReceiptParseItem(
+        product_name=_parse_required_text(
+            value.get('product_name'),
+            f'{path}.product_name',
+        ),
+        category=_parse_optional_text(value.get('category')) or 'Прочее',
+        price=price,
+        quantity=quantity,
+        amount=amount,
+    )
+
+
+def _validate_items_total(
+    total_sum: Decimal,
+    items: tuple[ReceiptParseItem, ...],
+) -> None:
+    items_total = sum((item.amount for item in items), Decimal(0))
+    if items_total <= 0:
+        raise ReceiptParseValidationError(
+            'receipt.items total must be positive',
+        )
+
+    allowed_diff = max(
+        total_sum * TOTAL_SUM_TOLERANCE_RATIO,
+        TOTAL_SUM_TOLERANCE_MIN,
+    )
+    if abs(total_sum - items_total) > allowed_diff:
+        raise ReceiptParseValidationError(
+            'receipt.total_sum differs from receipt.items total by more '
+            'than 2%',
+        )
+
+
+def _validate_object_keys(
+    payload: dict[str, Any],
+    allowed_keys: frozenset[str],
+    path: str,
+) -> None:
+    unknown_keys = sorted(set(payload) - allowed_keys)
+    if unknown_keys:
+        message = f'{path} contains unknown fields: {", ".join(unknown_keys)}'
+        raise ReceiptParseValidationError(
+            message,
+        )
+
+
+def _validate_required_fields(
+    payload: dict[str, Any],
+    required_keys: frozenset[str],
+    path: str,
+) -> None:
+    missing_keys = sorted(key for key in required_keys if key not in payload)
+    if missing_keys:
+        message = (
+            f'{path} is missing required fields: {", ".join(missing_keys)}'
+        )
+        raise ReceiptParseValidationError(
+            message,
+        )
+
+
+def _parse_decimal(value: Any, path: str) -> Decimal:
+    if isinstance(value, bool) or value is None:
+        message = f'{path} must be a number'
+        raise ReceiptParseValidationError(message)
+    try:
+        decimal_value = Decimal(str(value).replace(',', '.').replace(' ', ''))
+    except (InvalidOperation, ValueError) as exc:
+        message = f'{path} must be a number'
+        raise ReceiptParseValidationError(message) from exc
+    if not decimal_value.is_finite():
+        message = f'{path} must be a finite number'
+        raise ReceiptParseValidationError(message)
+    return decimal_value
+
+
+def _parse_optional_non_negative_decimal(
+    value: Any,
+    path: str,
+) -> Decimal | None:
+    if value is None or value == '':
+        return None
+    decimal_value = _parse_decimal(value, path)
+    if decimal_value < 0:
+        message = f'{path} must not be negative'
+        raise ReceiptParseValidationError(message)
+    return decimal_value
+
+
+def _parse_int(value: Any, path: str) -> int:
+    if isinstance(value, bool) or value is None:
+        message = f'{path} must be an integer'
+        raise ReceiptParseValidationError(message)
+    try:
+        return int(str(value).strip())
+    except ValueError as exc:
+        message = f'{path} must be an integer'
+        raise ReceiptParseValidationError(message) from exc
+
+
+def _parse_optional_int(value: Any, path: str) -> int | None:
+    if value is None or value == '':
+        return None
+    return _parse_int(value, path)
+
+
+def _parse_required_text(value: Any, path: str) -> str:
+    text = _parse_optional_text(value)
+    if text is None:
+        message = f'{path} must be a non-empty string'
+        raise ReceiptParseValidationError(message)
+    return text
+
+
+def _parse_optional_text(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _parse_receipt_date(value: Any) -> str:
+    text = _parse_required_text(value, 'receipt.receipt_date')
+    for date_format in ('%d.%m.%Y %H:%M', '%d.%m.%y %H:%M'):
+        try:
+            parsed = datetime.strptime(text, date_format).replace(tzinfo=UTC)
+        except ValueError:
+            continue
+        return parsed.strftime('%d.%m.%Y %H:%M')
+    raise ReceiptParseValidationError(
+        'receipt.receipt_date must be parseable as DD.MM.YYYY HH:MM',
+    )
+
+
+def _format_decimal(value: Decimal) -> str:
+    return format(value.quantize(Decimal('0.01')), 'f')
+
+
+def _format_optional_decimal(value: Decimal | None) -> str | None:
+    if value is None:
+        return None
+    return _format_decimal(value)
+
+
+__all__ = [
+    'RECEIPT_PARSE_SCHEMA',
+    'ReceiptParseResult',
+    'ReceiptParseValidationError',
+    'validate_receipt_parse_payload',
+]


### PR DESCRIPTION
Add schema validation and normalization for receipt-inference responses before pending receipts are processed. Reject invalid structures, unknown fields, bad amounts, and total mismatches so malformed AI payloads fail safely.