### PR TITLE
feat(auth): redesign login & registration with design tokens

### DIFF
--- a/hasta_la_vista_money/templates/forms/_field_auth.html
+++ b/hasta_la_vista_money/templates/forms/_field_auth.html
@@ -1,0 +1,33 @@
+{% load widget_tweaks %}
+
+{% if field.is_hidden %}
+    {{ field }}
+{% else %}
+    <div class="auth-field{% if field.errors %} is-invalid{% endif %}">
+        {% if field.field.widget.input_type == 'checkbox' %}
+            <label for="{{ field.id_for_label }}" class="auth-check">
+                {% render_field field class="auth-checkbox" %}
+                <span>{{ field.label }}</span>
+            </label>
+        {% else %}
+            {% if field.label %}
+                <label for="{{ field.id_for_label }}" class="auth-label">
+                    {{ field.label }}{% if field.field.required %}<span class="auth-required">*</span>{% endif %}
+                </label>
+            {% endif %}
+            {% render_field field class="auth-input" %}
+        {% endif %}
+
+        {% if field.help_text %}
+            <div class="auth-help">{{ field.help_text|safe }}</div>
+        {% endif %}
+
+        {% if field.errors %}
+            <div class="auth-field-errors">
+                {% for error in field.errors %}
+                    <p>{{ error }}</p>
+                {% endfor %}
+            </div>
+        {% endif %}
+    </div>
+{% endif %}

--- a/hasta_la_vista_money/users/templates/users/login.html
+++ b/hasta_la_vista_money/users/templates/users/login.html
@@ -1,66 +1,66 @@
 {% extends 'base.html' %}
 {% load i18n %}
+{% load static %}
 
 {% block title %}{% translate 'Страница входа' %}{% endblock %}
 
+{% block extra_head %}
+    <link nonce="{{ request.csp_nonce }}" rel="stylesheet" href="{% static 'auth/css/auth.css' %}">
+{% endblock %}
+
 {% block content %}
-<div class="flex min-h-screen items-center justify-center bg-gradient-to-br from-green-50 via-white to-emerald-50 px-4 py-12 dark:from-gray-900 dark:via-gray-800 dark:to-gray-900 sm:px-6 lg:px-8">
-    <div class="w-full max-w-md space-y-8">
-        <div class="text-center">
-            <div class="mx-auto mb-6 flex h-20 w-20 items-center justify-center rounded-full bg-gradient-to-br from-green-600 to-emerald-600 shadow-lg transition-transform duration-300 hover:scale-110">
-                <svg class="h-12 w-12 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+<div class="auth-shell">
+    <div class="auth-wrap">
+        <div class="auth-hero">
+            <div class="auth-badge">
+                <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2"/>
+                    <path d="M12 6v2M12 16v2"/>
+                    <circle cx="12" cy="12" r="10"/>
                 </svg>
             </div>
-            <h1 class="text-4xl font-bold">
-                <span class="text-green-600">Hasta La Vista, Money!</span>
+            <div class="auth-kicker">Hasta La Vista, Money</div>
+            <h1 class="auth-title">
+                <span class="auth-title-accent">{% translate 'Вход в приложение' %}</span>
             </h1>
-            <p class="mt-3 text-base text-gray-700 dark:text-gray-300">
-                {% translate 'Удобная домашняя бухгалтерия. Управляй финансами семьи грамотно!' %}
-            </p>
-            <h2 class="mt-6 text-xl font-semibold text-gray-900 dark:text-white">
-                {% translate 'Вход в приложение' %}
-            </h2>
+            <p class="auth-subtitle">{% translate 'Удобная домашняя бухгалтерия. Управляй финансами семьи грамотно!' %}</p>
         </div>
 
-        <div class="rounded-2xl bg-white p-8 shadow-xl transition-all duration-300 hover:shadow-2xl dark:bg-gray-800 dark:shadow-gray-900/50">
-            <form method="post" class="space-y-6 text-black dark:text-white dark:[&_label]:text-white dark:[&_small]:text-gray-300">
+        <div class="auth-card">
+            <form method="post" class="auth-form" novalidate>
                 {% csrf_token %}
 
                 {% if user_login_form %}
-                    {% for field in user_login_form %}
-                        <div>
-                            {% include 'forms/_field.html' with field=field %}
-                            {% if field.errors %}
-                                <div class="mt-2 text-sm text-red-600 dark:text-red-400">
-                                    {% for error in field.errors %}
-                                        <p>{{ error }}</p>
-                                    {% endfor %}
-                                </div>
-                            {% endif %}
-                        </div>
+                    {% for hidden in user_login_form.hidden_fields %}
+                        {{ hidden }}
+                    {% endfor %}
+
+                    {% for field in user_login_form.visible_fields %}
+                        {% include 'forms/_field_auth.html' with field=field %}
                     {% endfor %}
 
                     {% if user_login_form.non_field_errors %}
-                        <div class="rounded-xl bg-red-50 p-4 dark:bg-red-900/20">
-                            <div class="flex">
-                                <svg class="h-5 w-5 flex-shrink-0 text-red-600 dark:text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"></path>
-                                </svg>
-                                <div class="ml-3">
-                                    {% for error in user_login_form.non_field_errors %}
-                                        <p class="text-sm font-medium text-red-800 dark:text-red-200">{{ error }}</p>
-                                    {% endfor %}
-                                </div>
+                        <div class="auth-error">
+                            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">
+                                <circle cx="12" cy="12" r="10"/>
+                                <line x1="12" y1="8" x2="12" y2="12"/>
+                                <line x1="12" y1="16" x2="12.01" y2="16"/>
+                            </svg>
+                            <div>
+                                {% for error in user_login_form.non_field_errors %}
+                                    <p>{{ error }}</p>
+                                {% endfor %}
                             </div>
                         </div>
                     {% endif %}
                 {% endif %}
 
-                <div>
-                    <button type="submit" class="group relative w-full flex justify-center items-center gap-2 rounded-xl px-6 py-3 text-black bg-green-600 font-semibold shadow-lg transition-all duration-200 hover:shadow-xl focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 active:scale-95">
-                        <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 16l-4-4m0 0l4-4m-4 4h14m-5 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h7a3 3 0 013 3v1"></path>
+                <div class="auth-actions">
+                    <button type="submit" class="auth-button auth-button-primary">
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">
+                            <path d="M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4"/>
+                            <polyline points="10 17 15 12 10 7"/>
+                            <line x1="15" y1="12" x2="3" y2="12"/>
                         </svg>
                         {% translate 'Войти' %}
                     </button>
@@ -68,7 +68,7 @@
             </form>
 
             {% if redirect_to %}
-            <meta http-equiv="refresh" content="0;url={{ redirect_to }}">
+                <meta http-equiv="refresh" content="0;url={{ redirect_to }}">
             {% endif %}
         </div>
     </div>

--- a/hasta_la_vista_money/users/templates/users/registration.html
+++ b/hasta_la_vista_money/users/templates/users/registration.html
@@ -1,62 +1,68 @@
 {% extends 'base.html' %}
 {% load i18n %}
+{% load static %}
 
 {% block title %}{% translate 'Регистрация нового пользователя' %}{% endblock %}
 
+{% block extra_head %}
+    <link nonce="{{ request.csp_nonce }}" rel="stylesheet" href="{% static 'auth/css/auth.css' %}">
+{% endblock %}
+
 {% block content %}
-<div class="flex min-h-screen items-center justify-center bg-gradient-to-br from-green-50 via-white to-emerald-50 px-4 py-6 dark:from-gray-900 dark:via-gray-800 dark:to-gray-900 sm:px-6 lg:px-8">
-    <div class="w-full max-w-md space-y-4">
-        <div class="text-center">
-            <div class="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-gradient-to-br from-green-600 to-emerald-600 shadow-lg">
-                <svg class="h-6 w-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18 9v3m0 0v3m0-3h3m-3 0h-3m-2-5a4 4 0 11-8 0 4 4 0 018 0zM3 20a6 6 0 0112 0v1H3v-1z"></path>
+<div class="auth-shell">
+    <div class="auth-wrap">
+        <div class="auth-hero">
+            <div class="auth-badge">
+                <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/>
+                    <circle cx="9" cy="7" r="4"/>
+                    <path d="M19 8v6M22 11h-6"/>
                 </svg>
             </div>
-            <h1 class="text-2xl font-bold tracking-tight text-black dark:text-white">
-                {% translate 'Регистрация нового пользователя' %}
-            </h1>
-            <p class="mt-1 text-xs text-black dark:text-white">
-                {% translate 'Создайте аккаунт для управления личными финансами' %}
-            </p>
+            <div class="auth-kicker">{% translate 'Аккаунт' %}</div>
+            <h1 class="auth-title">{% translate 'Регистрация' %}</h1>
+            <p class="auth-subtitle">{% translate 'Создайте аккаунт для управления личными финансами' %}</p>
         </div>
 
-        <div class="rounded-2xl bg-white p-6 shadow-xl dark:bg-gray-800 dark:shadow-gray-900/50">
-            <form method="post" class="space-y-4 text-black dark:text-white dark:[&_label]:text-white dark:[&_small]:text-gray-300 dark:[&_.form-text]:text-gray-300 dark:[&_.help-block]:text-gray-300 dark:[&_.text-muted]:text-gray-300 dark:[&_span.text-muted]:text-gray-300">
+        <div class="auth-card">
+            <form method="post" class="auth-form" novalidate>
                 {% csrf_token %}
-                
-                {% include 'forms/_form.html' with form=form %}
-                
+
+                {% for hidden in form.hidden_fields %}
+                    {{ hidden }}
+                {% endfor %}
+
+                {% for field in form.visible_fields %}
+                    {% include 'forms/_field_auth.html' with field=field %}
+                {% endfor %}
+
                 {% if form.non_field_errors %}
-                    <div class="rounded-xl bg-red-50 p-3 dark:bg-red-900/20">
-                        <div class="flex">
-                            <svg class="h-4 w-4 flex-shrink-0 text-red-600 dark:text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"></path>
-                            </svg>
-                            <div class="ml-2">
-                                {% for error in form.non_field_errors %}
-                                    <p class="text-xs font-medium text-red-800 dark:text-red-200">{{ error }}</p>
-                                {% endfor %}
-                            </div>
+                    <div class="auth-error">
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">
+                            <circle cx="12" cy="12" r="10"/>
+                            <line x1="12" y1="8" x2="12" y2="12"/>
+                            <line x1="12" y1="16" x2="12.01" y2="16"/>
+                        </svg>
+                        <div>
+                            {% for error in form.non_field_errors %}
+                                <p>{{ error }}</p>
+                            {% endfor %}
                         </div>
                     </div>
                 {% endif %}
 
-                <div class="flex flex-col gap-3 sm:flex-row sm:justify-between">
-                    <button type="submit" class="group relative flex w-full items-center justify-center gap-2 rounded-xl bg-gradient-to-r from-green-600 to-emerald-600 px-5 py-2 text-sm font-semibold text-dark shadow-lg shadow-green-500/30 transition-all duration-200 hover:from-green-700 hover:to-emerald-700 hover:shadow-xl hover:shadow-green-500/40 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 active:scale-95 sm:w-auto">
-                        <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18 9v3m0 0v3m0-3h3m-3 0h-3m-2-5a4 4 0 11-8 0 4 4 0 018 0zM3 20a6 6 0 0112 0v1H3v-1z"></path>
+                <div class="auth-actions">
+                    <button type="submit" class="auth-button auth-button-primary">
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">
+                            <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/>
+                            <circle cx="9" cy="7" r="4"/>
+                            <path d="M19 8v6M22 11h-6"/>
                         </svg>
                         {% translate 'Зарегистрироваться' %}
                     </button>
-                    
-                    <a href="{% url 'login' %}" class="flex w-full items-center justify-center gap-2 rounded-xl border-2 border-gray-300 bg-white px-5 py-2 text-sm font-semibold text-black transition-all duration-200 hover:border-gray-400 hover:bg-gray-50 active:scale-95 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:hover:border-gray-500 dark:hover:bg-gray-700 sm:w-auto">
-                        <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18"></path>
-                        </svg>
-                        {% translate 'Вернуться назад' %}
-                    </a>
                 </div>
             </form>
         </div>
+    </div>
 </div>
 {% endblock %}

--- a/static/auth/css/auth.css
+++ b/static/auth/css/auth.css
@@ -1,0 +1,342 @@
+.auth-shell {
+  --app-bg: #f0f7f4;
+  --app-surface: #ffffff;
+  --app-surface-2: #e8f3ee;
+  --app-text: #0d1f1a;
+  --app-muted: #4a6d5e;
+  --app-positive: #059669;
+  --app-negative: #dc2626;
+  --app-accent: #10b981;
+
+  min-height: 100vh;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2.5rem 1rem;
+  background:
+    radial-gradient(ellipse 70% 50% at 0% 0%, color-mix(in oklab, var(--app-accent) 14%, transparent), transparent),
+    radial-gradient(ellipse 55% 45% at 100% 100%, color-mix(in oklab, var(--app-positive) 10%, transparent), transparent),
+    var(--app-bg);
+  color: var(--app-text);
+}
+
+[data-bs-theme='dark'] .auth-shell {
+  --app-bg: #0b1120;
+  --app-surface: #111827;
+  --app-surface-2: #1a2535;
+  --app-text: #e2e8f0;
+  --app-muted: #94a3b8;
+  --app-positive: #059669;
+  --app-negative: #dc2626;
+  --app-accent: #10b981;
+}
+
+body:has(> .auth-shell) {
+  background: var(--app-bg);
+}
+
+.auth-wrap {
+  width: 100%;
+  max-width: 28rem;
+}
+
+.auth-hero {
+  text-align: center;
+  margin-bottom: 1.75rem;
+}
+
+.auth-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 3rem;
+  height: 3rem;
+  margin: 0 auto 1rem;
+  border-radius: 999px;
+  background: linear-gradient(135deg, var(--app-positive), var(--app-accent));
+  color: #fff;
+  box-shadow: 0 14px 30px color-mix(in oklab, var(--app-accent) 28%, transparent);
+}
+
+.auth-kicker {
+  color: var(--app-muted);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin-bottom: 0.5rem;
+}
+
+.auth-title {
+  font-size: clamp(1.6rem, 3vw, 2rem);
+  font-weight: 800;
+  letter-spacing: -0.04em;
+  line-height: 1.1;
+  color: var(--app-text);
+  margin: 0;
+}
+
+.auth-title-accent {
+  background: linear-gradient(135deg, var(--app-positive), var(--app-accent));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.auth-subtitle {
+  color: var(--app-muted);
+  font-size: 0.9rem;
+  line-height: 1.5;
+  margin: 0.6rem 0 0;
+}
+
+.auth-card {
+  background: var(--app-surface);
+  border: 1px solid color-mix(in oklab, var(--app-text) 10%, transparent);
+  border-radius: 1.25rem;
+  padding: 1.75rem;
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.04),
+    0 24px 48px -12px color-mix(in oklab, var(--app-accent) 18%, rgba(0, 0, 0, 0.08));
+}
+
+[data-bs-theme='dark'] .auth-card {
+  border-color: color-mix(in oklab, var(--app-text) 14%, transparent);
+}
+
+[data-bs-theme='dark'] .auth-card {
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.4),
+    0 24px 48px -12px rgba(0, 0, 0, 0.5);
+}
+
+.auth-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.auth-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.auth-label {
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--app-text);
+  display: block;
+}
+
+.auth-required {
+  color: var(--app-negative);
+  margin-left: 0.25rem;
+}
+
+.auth-input {
+  appearance: none;
+  -webkit-appearance: none;
+  width: 100%;
+  background-color: var(--app-surface);
+  background-image: none;
+  border-style: solid;
+  border-width: 1px;
+  border-color: color-mix(in oklab, var(--app-text) 18%, transparent);
+  border-radius: 0.75rem;
+  color: var(--app-text);
+  font-size: 0.9rem;
+  font-family: inherit;
+  line-height: 1.4;
+  padding: 0.65rem 0.85rem;
+  min-height: 2.65rem;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+  transition: border-color 0.15s ease, box-shadow 0.15s ease, background-color 0.15s ease;
+}
+
+[data-bs-theme='dark'] .auth-input {
+  background-color: var(--app-surface-2);
+  border-color: color-mix(in oklab, var(--app-text) 22%, transparent);
+  box-shadow: none;
+}
+
+.auth-input::placeholder {
+  color: color-mix(in oklab, var(--app-muted) 70%, transparent);
+}
+
+.auth-input:focus {
+  outline: none;
+  border-color: var(--app-accent);
+  background: var(--app-surface);
+  box-shadow: 0 0 0 3px color-mix(in oklab, var(--app-accent) 18%, transparent);
+}
+
+.auth-input:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.auth-check {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+  color: var(--app-text);
+  cursor: pointer;
+}
+
+.auth-checkbox {
+  width: 1rem;
+  height: 1rem;
+  accent-color: var(--app-accent);
+}
+
+.auth-help {
+  font-size: 0.75rem;
+  line-height: 1.45;
+  color: var(--app-muted);
+}
+
+.auth-help ul {
+  margin: 0;
+  padding-left: 1.1rem;
+  list-style: disc;
+}
+
+.auth-help li {
+  margin: 0.1rem 0;
+}
+
+.auth-help p {
+  margin: 0;
+}
+
+.auth-field-errors {
+  color: var(--app-negative);
+  font-size: 0.78rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.auth-field-errors p {
+  margin: 0;
+}
+
+.auth-field.is-invalid .auth-input {
+  border-color: var(--app-negative);
+  box-shadow: 0 0 0 3px color-mix(in oklab, var(--app-negative) 16%, transparent);
+}
+
+.auth-error {
+  border: 1px solid color-mix(in oklab, var(--app-negative) 30%, var(--app-border));
+  background: color-mix(in oklab, var(--app-negative) 8%, var(--app-surface));
+  color: var(--app-negative);
+  border-radius: 0.85rem;
+  padding: 0.65rem 0.85rem;
+  font-size: 0.85rem;
+  display: flex;
+  gap: 0.55rem;
+  align-items: flex-start;
+}
+
+.auth-error svg {
+  flex-shrink: 0;
+  margin-top: 0.15rem;
+}
+
+.auth-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  margin-top: 0.5rem;
+}
+
+.auth-button {
+  appearance: none;
+  -webkit-appearance: none;
+  border-style: solid;
+  border-width: 1px;
+  border-color: transparent;
+  border-radius: 0.85rem;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  padding: 0.75rem 1.25rem;
+  min-height: 2.75rem;
+  width: 100%;
+  text-decoration: none;
+  font-family: inherit;
+  line-height: 1.2;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, filter 0.15s ease, border-color 0.15s ease;
+}
+
+.auth-button:hover {
+  transform: translateY(-1px);
+}
+
+.auth-button-primary,
+button.auth-button-primary {
+  background-color: var(--app-accent);
+  background-image: linear-gradient(135deg, var(--app-positive), var(--app-accent));
+  color: #fff !important;
+  box-shadow: 0 10px 24px color-mix(in oklab, var(--app-accent) 30%, transparent);
+}
+
+.auth-button-primary:hover {
+  box-shadow: 0 14px 30px color-mix(in oklab, var(--app-accent) 40%, transparent);
+  filter: brightness(1.05);
+}
+
+.auth-button-ghost,
+a.auth-button-ghost {
+  background-color: var(--app-surface);
+  background-image: none;
+  border-color: color-mix(in oklab, var(--app-text) 18%, transparent);
+  color: var(--app-text) !important;
+}
+
+.auth-button-ghost:hover {
+  border-color: color-mix(in oklab, var(--app-text) 30%, transparent);
+}
+
+.auth-footer {
+  margin-top: 1.25rem;
+  text-align: center;
+  font-size: 0.82rem;
+  color: var(--app-muted);
+}
+
+.auth-footer a {
+  color: var(--app-accent);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.auth-footer a:hover {
+  text-decoration: underline;
+}
+
+@media (max-width: 480px) {
+  .auth-shell {
+    padding: 1.25rem 0.75rem;
+  }
+
+  .auth-card {
+    padding: 1.25rem;
+    border-radius: 1rem;
+  }
+
+  .auth-actions {
+    flex-direction: column;
+  }
+
+  .auth-button {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
- Add static/auth/css/auth.css using global --app-* tokens (light/dark)
- Add forms/_field_auth.html partial to render fields without Tailwind reset conflicts
- Rebuild login.html and registration.html on top of new auth shell/card