### PR TITLE
feat(finances): add inline category editing in tree

### DIFF
--- a/hasta_la_vista_money/finance_account/templates/finance_account/partials/_category_tree_item.html
+++ b/hasta_la_vista_money/finance_account/templates/finance_account/partials/_category_tree_item.html
@@ -9,14 +9,23 @@
                 <svg viewBox="0 0 24 24" width="9" height="9" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/></svg>
             {% endif %}
         </span>
-        <div class="finance-category-name">
+        <button type="button"
+                class="finance-category-name"
+                title="{% translate 'Редактировать категорию' %}"
+                hx-get="{% url 'transactions:update_category' category.id %}?inline=1"
+                hx-target="closest article"
+                hx-swap="outerHTML">
             <strong>{{ category.name }}</strong>
             {% if category.total_children_count %}
                 <span>{{ category.total_children_count }} {% translate 'подкат.' %}</span>
             {% endif %}
-        </div>
+        </button>
         <div class="finance-category-actions">
-            <a href="{% url 'transactions:update_category' category.id %}" title="{% translate 'Редактировать категорию' %}">
+            <a href="{% url 'transactions:update_category' category.id %}"
+               title="{% translate 'Редактировать категорию' %}"
+               hx-get="{% url 'transactions:update_category' category.id %}?inline=1"
+               hx-target="closest article"
+               hx-swap="outerHTML">
                 <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4Z"/></svg>
             </a>
             <form method="post" action="{% url 'transactions:delete_category' category.id %}">

--- a/hasta_la_vista_money/transactions/templates/transactions/partials/_category_tree_item_form.html
+++ b/hasta_la_vista_money/transactions/templates/transactions/partials/_category_tree_item_form.html
@@ -1,0 +1,54 @@
+{% load i18n %}
+
+<article class="finance-category-item finance-category-level-{{ level }}" style="--cat-level: {{ level }};">
+    <form method="post"
+          class="finance-category-row finance-category-inline-form"
+          hx-post="{% url 'transactions:update_category' category.id %}?inline=1"
+          hx-target="closest article"
+          hx-swap="outerHTML">
+        {% csrf_token %}
+        <input type="hidden" name="inline" value="1">
+        {{ form.type }}
+        {% if category.parent_category %}
+            <input type="hidden" name="parent_category" value="{{ category.parent_category }}">
+        {% else %}
+            <input type="hidden" name="parent_category" value="">
+        {% endif %}
+        <span class="dot">
+            {% if category_type == 'income' %}
+                <svg viewBox="0 0 24 24" width="9" height="9" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14M5 12h14"/></svg>
+            {% else %}
+                <svg viewBox="0 0 24 24" width="9" height="9" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/></svg>
+            {% endif %}
+        </span>
+        <div class="finance-category-name finance-category-inline-name">
+            <label for="{{ form.name.id_for_label }}" class="sr-only">{% translate 'Название категории' %}</label>
+            {{ form.name }}
+            {% if form.name.errors %}
+                <span>{{ form.name.errors|join:', ' }}</span>
+            {% elif category.total_children_count %}
+                <span>{{ category.total_children_count }} {% translate 'подкат.' %}</span>
+            {% endif %}
+        </div>
+        <div class="finance-category-actions">
+            <button type="submit" title="{% translate 'Сохранить категорию' %}">
+                <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>
+            </button>
+            <button type="button"
+                    title="{% translate 'Отмена' %}"
+                    hx-get="{% url 'transactions:update_category' category.id %}?inline=1"
+                    hx-target="closest article"
+                    hx-swap="outerHTML">
+                <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18M6 6l12 12"/></svg>
+            </button>
+        </div>
+    </form>
+
+    {% if category.children %}
+        <div class="finance-category-children">
+            {% for child in category.children %}
+                {% include 'finance_account/partials/_category_tree_item.html' with category=child category_type=category_type level=level|add:1 %}
+            {% endfor %}
+        </div>
+    {% endif %}
+</article>

--- a/hasta_la_vista_money/transactions/tests/test_views.py
+++ b/hasta_la_vista_money/transactions/tests/test_views.py
@@ -84,6 +84,46 @@ class CategoryCRUDViewsTest(TestCase):
         category.refresh_from_db()
         self.assertEqual(category.name, 'Новое')
 
+    def test_update_get_htmx_renders_inline_form(self) -> None:
+        category = Category.objects.create(
+            user=self.user,
+            name='Редактируемая',
+            type=TransactionType.EXPENSE,
+        )
+        response = self.client.get(
+            reverse('transactions:update_category', args=[category.pk])
+            + '?inline=1',
+            HTTP_HX_REQUEST='true',
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(
+            response,
+            'transactions/partials/_category_tree_item_form.html',
+        )
+        self.assertContains(response, 'hx-post')
+
+    def test_update_post_htmx_returns_inline_item(self) -> None:
+        category = Category.objects.create(
+            user=self.user,
+            name='Старое',
+            type=TransactionType.EXPENSE,
+        )
+        response = self.client.post(
+            reverse('transactions:update_category', args=[category.pk])
+            + '?inline=1',
+            data={
+                'name': 'Новое',
+                'type': 'expense',
+                'parent_category': '',
+                'inline': '1',
+            },
+            HTTP_HX_REQUEST='true',
+        )
+        self.assertEqual(response.status_code, 200)
+        category.refresh_from_db()
+        self.assertEqual(category.name, 'Новое')
+        self.assertContains(response, 'finance-category-row')
+
     def test_update_rejects_foreign_category(self) -> None:
         other = User.objects.create_user(
             username='other',

--- a/hasta_la_vista_money/transactions/views.py
+++ b/hasta_la_vista_money/transactions/views.py
@@ -7,11 +7,12 @@ from django.contrib.auth.mixins import LoginRequiredMixin
 from django.core.cache import cache
 from django.db.models import ProtectedError
 from django.http import HttpResponse
-from django.shortcuts import get_object_or_404, redirect
+from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse_lazy
 from django.utils.translation import gettext_lazy as _
 from django.views.generic import CreateView, DeleteView, ListView, UpdateView
 
+from hasta_la_vista_money.services.views import get_cached_category_tree
 from hasta_la_vista_money.transactions.forms import CategoryForm
 from hasta_la_vista_money.transactions.models import Category, TransactionType
 from hasta_la_vista_money.users.services.cache import (
@@ -29,6 +30,22 @@ def _category_type(value: str | None) -> str:
 def _clear_category_cache(user_id: int, category_type: str) -> None:
     for depth in range(1, 6):
         cache.delete(f'category_tree_{category_type}_{user_id}_{depth}')
+
+
+def _find_category_node(
+    categories: list[dict[str, Any]],
+    category_id: int,
+    *,
+    level: int = 0,
+) -> tuple[dict[str, Any], int] | None:
+    for category in categories:
+        if category['id'] == category_id:
+            return category, level
+        children = category.get('children') or []
+        found = _find_category_node(children, category_id, level=level + 1)
+        if found is not None:
+            return found
+    return None
 
 
 class CategoryListView(LoginRequiredMixin, ListView[Category]):
@@ -89,11 +106,29 @@ class CategoryUpdateView(
     template_name = 'transactions/category_form.html'
     success_url = reverse_lazy('finances_categories')
 
+    def is_inline_request(self) -> bool:
+        return (
+            self.request.headers.get('HX-Request') == 'true'
+            and self.request.GET.get('inline') == '1'
+        ) or (
+            self.request.headers.get('HX-Request') == 'true'
+            and self.request.POST.get('inline') == '1'
+        )
+
     def get_object(self, queryset: Any = None) -> Category:
         return get_object_or_404(
             Category,
             pk=self.kwargs['pk'],
             user=self.request.user,
+        )
+
+    def get(self, request: Any, *args: Any, **kwargs: Any) -> HttpResponse:
+        if not self.is_inline_request():
+            return super().get(request, *args, **kwargs)
+        self.object = self.get_object()
+        return self._render_inline_form(
+            form=self.get_form(),
+            status=200,
         )
 
     def get_form_kwargs(self) -> dict[str, Any]:
@@ -106,6 +141,78 @@ class CategoryUpdateView(
         kwargs.setdefault('initial', {})['type'] = category.type
         return kwargs
 
+    def _inline_item_context(self, category: Category) -> dict[str, Any]:
+        tree = get_cached_category_tree(
+            user_id=self.request.user.pk,
+            category_type=category.type,
+            categories=list(
+                Category.objects.filter(
+                    user=self.request.user,
+                    type=category.type,
+                )
+                .values(
+                    'id',
+                    'name',
+                    'parent_category',
+                    'parent_category__name',
+                )
+                .order_by('parent_category_id')
+            ),
+            depth=3,
+        )
+        found = _find_category_node(tree, category.pk)
+        if found is None:
+            node = {
+                'id': category.pk,
+                'name': category.name,
+                'parent_category': category.parent_category_id,
+                'parent_category__name': (
+                    category.parent_category.name
+                    if category.parent_category is not None
+                    else ''
+                ),
+                'total_children_count': category.subcategories.count(),
+                'children': [],
+            }
+            level = 0
+        else:
+            node, level = found
+        return {
+            'category': node,
+            'category_type': category.type,
+            'level': level,
+        }
+
+    def _render_inline_form(
+        self,
+        *,
+        form: CategoryForm,
+        status: int,
+    ) -> HttpResponse:
+        category = self.get_object()
+        name_attrs = form.fields['name'].widget.attrs
+        name_attrs.update(
+            {
+                'class': 'finance-category-inline-input',
+                'autocomplete': 'off',
+            },
+        )
+        context = self._inline_item_context(category)
+        context['form'] = form
+        return render(
+            self.request,
+            'transactions/partials/_category_tree_item_form.html',
+            context=context,
+            status=status,
+        )
+
+    def _render_inline_item(self, *, category: Category) -> HttpResponse:
+        return render(
+            self.request,
+            'finance_account/partials/_category_tree_item.html',
+            context=self._inline_item_context(category),
+        )
+
     def form_valid(self, form: CategoryForm) -> HttpResponse:
         category = form.save(commit=False)
         category.user = self.request.user
@@ -113,8 +220,15 @@ class CategoryUpdateView(
         category.save()
         _clear_category_cache(self.request.user.pk, category.type)
         invalidate_user_detailed_statistics_cache(self.request.user.pk)
+        if self.is_inline_request():
+            return self._render_inline_item(category=category)
         messages.success(self.request, _('Категория успешно обновлена.'))
         return redirect(self.success_url)
+
+    def form_invalid(self, form: CategoryForm) -> HttpResponse:
+        if self.is_inline_request():
+            return self._render_inline_form(form=form, status=422)
+        return super().form_invalid(form)
 
 
 class CategoryDeleteView(LoginRequiredMixin, DeleteView[Category, Any]):

--- a/static/finances/css/finances.css
+++ b/static/finances/css/finances.css
@@ -1478,9 +1478,15 @@
 }
 
 .finance-category-name {
+  background: transparent;
+  border: 0;
+  color: inherit;
+  cursor: pointer;
   display: grid;
   gap: 2px;
   min-width: 0;
+  padding: 0;
+  text-align: left;
 }
 
 .finance-category-name strong {
@@ -1495,6 +1501,58 @@
   color: var(--finances-muted);
   font-family: var(--font-mono);
   font-size: 11px;
+}
+
+.finance-category-inline-name {
+  cursor: default;
+}
+
+.finance-category-inline-input {
+  appearance: none;
+  background: var(--finances-surface);
+  border: 1px solid color-mix(in oklab, var(--cat-c) 32%, var(--finances-border));
+  border-radius: 12px;
+  color: inherit;
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.2;
+  margin: 0;
+  min-height: 38px;
+  outline: none;
+  padding: 9px 12px;
+  transition: border-color 0.15s ease, background 0.15s ease;
+  width: 100%;
+}
+
+.finance-category-inline-input::placeholder {
+  color: var(--finances-muted);
+  font-weight: 500;
+}
+
+.finance-category-inline-input:hover {
+  border-color: color-mix(in oklab, var(--cat-c) 48%, var(--finances-border));
+}
+
+.finance-category-inline-input:focus,
+.finance-category-inline-input:focus-visible {
+  background: color-mix(in oklab, var(--cat-c) 4%, var(--finances-surface));
+  border-color: color-mix(in oklab, var(--cat-c) 58%, var(--finances-border));
+  box-shadow: none;
+  outline: none;
+}
+
+.finance-category-inline-form .finance-category-actions button[type='submit'] {
+  color: var(--cat-c);
+}
+
+.finance-category-inline-form .finance-category-actions button[type='submit']:hover {
+  background: color-mix(in oklab, var(--cat-c) 12%, transparent);
+  color: var(--cat-c);
+}
+
+.finance-category-inline-form .finance-category-actions button[type='button']:hover {
+  background: color-mix(in oklab, var(--finances-negative) 10%, transparent);
+  color: var(--finances-negative);
 }
 
 .finance-category-actions {


### PR DESCRIPTION
Add HTMX inline edit flow for category tree rows so users can rename categories without leaving the page. Return partial responses for inline GET/POST and cover behavior with dedicated view tests.