### PR TITLE
feat(receipts): add mobile camera QR scanning for receipt upload

### DIFF
--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -10,6 +10,7 @@ const options = {
     'pages/receipts': 'static/js/pages/receipts.js',
     'pages/reports': 'static/js/pages/reports.js',
     'pages/receipt-update': 'static/js/pages/receipt-update.js',
+    'pages/receipt-qr-scan': 'static/js/pages/receipt-qr-scan.js',
     'pages/loan': 'static/js/pages/loan.js',
     'pages/profile': 'static/js/pages/profile.js',
   },

--- a/hasta_la_vista_money/receipts/forms.py
+++ b/hasta_la_vista_money/receipts/forms.py
@@ -18,6 +18,7 @@ from django.forms import (
     DecimalField,
     FileField,
     Form,
+    HiddenInput,
     ModelChoiceField,
     ModelForm,
     NumberInput,
@@ -48,6 +49,10 @@ from hasta_la_vista_money.receipts.models import (
 from hasta_la_vista_money.receipts.parsers.date_parser import (
     ReceiptDateParseError,
     ReceiptDateParser,
+)
+from hasta_la_vista_money.receipts.services.fns_qr import (
+    QRCodeDecodeError,
+    parse_fns_qr,
 )
 
 _INPUT_CLASSES = (
@@ -559,6 +564,39 @@ class UploadImageForm(Form):
                     ),
                 )
         return self.cleaned_data.get('file')
+
+
+class ScanQRForm(Form):
+    """Form for submitting a QR string decoded by the browser camera."""
+
+    account = ModelChoiceField(
+        label=_('Счёт'),
+        queryset=Account.objects.all(),
+        widget=Select(attrs={'class': _SELECT_CLASSES}),
+    )
+    qr_raw = CharField(
+        widget=HiddenInput(),
+        max_length=512,
+    )
+
+    def __init__(self, user: User, *args: Any, **kwargs: Any) -> None:
+        kwargs.pop('user', None)
+        super().__init__(*args, **kwargs)
+        self.fields['account'].queryset = Account.objects.filter(user=user)  # type: ignore[attr-defined]
+        if self.fields['account'].queryset.exists():  # type: ignore[attr-defined]
+            self.fields['account'].initial = self.fields[
+                'account'
+            ].queryset.first()  # type: ignore[attr-defined]
+
+    def clean_qr_raw(self) -> str:
+        qr_raw = (self.cleaned_data.get('qr_raw') or '').strip()
+        if not qr_raw:
+            raise ValidationError(_('QR-код не распознан.'))
+        try:
+            parse_fns_qr(qr_raw)
+        except QRCodeDecodeError as exc:
+            raise ValidationError(str(exc)) from exc
+        return qr_raw
 
 
 class PendingReceiptReviewForm(Form):

--- a/hasta_la_vista_money/receipts/protocols/services.py
+++ b/hasta_la_vista_money/receipts/protocols/services.py
@@ -97,6 +97,14 @@ class PendingReceiptServiceProtocol(Protocol):
         image_hash: str,
     ) -> PendingReceipt: ...
 
+    def create_processing_job_from_qr(
+        self,
+        *,
+        user: User,
+        account: Account,
+        image_hash: str,
+    ) -> PendingReceipt: ...
+
     def attach_task_id(
         self,
         *,

--- a/hasta_la_vista_money/receipts/services/pending_receipt_service.py
+++ b/hasta_la_vista_money/receipts/services/pending_receipt_service.py
@@ -162,6 +162,35 @@ class PendingReceiptService:
             image_hash=image_hash,
         )
 
+    def create_processing_job_from_qr(
+        self,
+        *,
+        user: User,
+        account: Account,
+        image_hash: str,
+    ) -> PendingReceipt:
+        """Persist a new PendingReceipt from a browser camera QR scan.
+
+        Unlike ``create_processing_job``, there is no uploaded image: the QR
+        was already decoded client-side, so ``image_file`` stays empty and
+        ``image_hash`` is the SHA-256 of the raw QR string — reusing the
+        same dedup mechanism as photo uploads.
+
+        Args:
+            user: Owner of the receipt.
+            account: Account that will be charged for the receipt.
+            image_hash: SHA-256 hex digest of the raw QR string.
+
+        Returns:
+            Newly created PendingReceipt.
+        """
+        return PendingReceipt.objects.create(
+            user=user,
+            account=account,
+            status=PendingReceiptStatus.PROCESSING,
+            image_hash=image_hash,
+        )
+
     def attach_task_id(
         self,
         *,

--- a/hasta_la_vista_money/receipts/static/receipts/css/receipts.css
+++ b/hasta_la_vista_money/receipts/static/receipts/css/receipts.css
@@ -1177,6 +1177,54 @@
   padding: 0.65rem 0.9rem;
 }
 
+.receipts-mode-tabs {
+  display: none;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+@media (max-width: 768px) {
+  .receipts-mode-tabs {
+    display: flex;
+  }
+}
+
+.receipts-mode-tab {
+  align-items: center;
+  background: var(--receipts-surface-2);
+  border: 1px solid var(--receipts-border);
+  border-radius: 0.75rem;
+  color: var(--receipts-muted);
+  cursor: pointer;
+  display: flex;
+  font-size: 0.85rem;
+  font-weight: 600;
+  gap: 0.4rem;
+  padding: 0.5rem 0.9rem;
+}
+
+.receipts-mode-tab.is-active {
+  background: color-mix(in oklab, var(--receipts-accent) 12%, var(--receipts-surface));
+  border-color: color-mix(in oklab, var(--receipts-accent) 45%, var(--receipts-border));
+  color: var(--receipts-accent);
+}
+
+.receipts-scan-panel {
+  display: grid;
+  gap: 1rem;
+}
+
+.receipts-scan-video-wrap {
+  background: #000;
+  border-radius: 1.25rem;
+  overflow: hidden;
+}
+
+.receipts-scan-video {
+  display: block;
+  width: 100%;
+}
+
 /* Review */
 .receipt-review-form {
   display: grid;

--- a/hasta_la_vista_money/receipts/static/receipts/css/receipts.css
+++ b/hasta_la_vista_money/receipts/static/receipts/css/receipts.css
@@ -1107,7 +1107,15 @@
 
 .receipts-dropzone-icon {
   color: var(--receipts-muted);
-  font-size: 2rem;
+  flex-shrink: 0;
+  height: 2rem;
+  width: 2rem;
+}
+
+.receipts-icon {
+  flex-shrink: 0;
+  height: 1rem;
+  width: 1rem;
 }
 
 .receipts-dropzone-text {
@@ -1181,11 +1189,18 @@
   display: none;
   gap: 0.5rem;
   margin-bottom: 1rem;
+  margin-left: auto;
+  margin-right: auto;
+  margin-top: 1rem;
 }
 
 @media (max-width: 768px) {
   .receipts-mode-tabs {
     display: flex;
+  }
+
+  .receipts-card-ft {
+    bottom: 0rem;
   }
 }
 

--- a/hasta_la_vista_money/receipts/tasks.py
+++ b/hasta_la_vista_money/receipts/tasks.py
@@ -155,12 +155,17 @@ def _get_pending_receipt_service() -> PendingReceiptServiceProtocol:
     return ApplicationContainer().receipts.pending_receipt_service()
 
 
-def _run_fns_pipeline(pending: PendingReceipt) -> dict[str, Any]:
-    """Process a pending receipt through QR -> FNS -> mapper pipeline."""
-    with pending.image_file.open('rb') as image_fp:
-        qr_data = QRCodeExtractor().extract(image_fp)
+def _run_fns_pipeline_from_raw(
+    pending: PendingReceipt,
+    raw_qr: str,
+) -> dict[str, Any]:
+    """Run the FNS lookup -> mapper -> validate tail from a decoded QR string.
 
-    fns_payload = FNSClient().fetch_receipt(qr_data.raw)
+    Shared by the photo-upload pipeline (which extracts ``raw_qr`` from the
+    image first) and the browser-camera-scan pipeline (which already has
+    the decoded string and skips extraction entirely).
+    """
+    fns_payload = FNSClient().fetch_receipt(raw_qr)
     receipt_data = map_fns_receipt_to_receipt_data(fns_payload)
     receipt_data['items'] = ReceiptItemCategoryService().categorize_items(
         user=pending.user,
@@ -176,6 +181,13 @@ def _run_fns_pipeline(pending: PendingReceipt) -> dict[str, Any]:
     validated = validate_receipt_parse_payload(receipt_data).to_dict()
     validated['_fns_raw'] = fns_payload
     return validated
+
+
+def _run_fns_pipeline(pending: PendingReceipt) -> dict[str, Any]:
+    """Process a pending receipt through QR -> FNS -> mapper pipeline."""
+    with pending.image_file.open('rb') as image_fp:
+        qr_data = QRCodeExtractor().extract(image_fp)
+    return _run_fns_pipeline_from_raw(pending, qr_data.raw)
 
 
 def _run_processing_pipeline(pending: PendingReceipt) -> dict[str, Any]:

--- a/hasta_la_vista_money/receipts/tasks.py
+++ b/hasta_la_vista_money/receipts/tasks.py
@@ -6,6 +6,7 @@ live here so the work survives the user closing the page.
 """
 
 import json
+from collections.abc import Callable
 from datetime import timedelta
 from typing import Any
 
@@ -212,6 +213,37 @@ def _classify_failure(exc: Exception) -> tuple[str, str]:
     return 'pending_receipt_failed', str(_UNEXPECTED_MESSAGE)
 
 
+def _finalize_pipeline(
+    pending: PendingReceipt,
+    pending_receipt_id: int,
+    service: PendingReceiptServiceProtocol,
+    run_pipeline: Callable[[], dict[str, Any]],
+) -> None:
+    """Run a pipeline callable and transition the pending receipt.
+
+    Shared tail for both processing tasks: catches pipeline failures,
+    classifies them, and marks the pending receipt failed or ready.
+    """
+    try:
+        receipt_data = run_pipeline()
+    except Exception as exc:
+        event, message = _classify_failure(exc)
+        service.mark_failed(
+            pending_receipt=pending,
+            error_message=message,
+        )
+        logger.warning(
+            event,
+            pending_receipt_id=pending_receipt_id,
+            error=str(exc),
+        )
+        return
+    service.mark_ready(
+        pending_receipt=pending,
+        receipt_data=receipt_data,
+    )
+
+
 @shared_task(  # type: ignore[untyped-decorator]
     bind=True,
     name='receipts.process_pending_receipt',
@@ -251,24 +283,55 @@ def process_pending_receipt(_self: Any, pending_receipt_id: int) -> None:
         )
         return
 
+    _finalize_pipeline(
+        pending,
+        pending_receipt_id,
+        service,
+        lambda: _run_processing_pipeline(pending),
+    )
+
+
+@shared_task(  # type: ignore[untyped-decorator]
+    bind=True,
+    name='receipts.process_pending_receipt_from_qr',
+    autoretry_for=(ConnectionError,),
+    max_retries=2,
+    retry_backoff=True,
+    acks_late=True,
+)
+def process_pending_receipt_from_qr(
+    _self: Any,
+    pending_receipt_id: int,
+    raw_qr: str,
+) -> None:
+    """Run the FNS lookup for a pending receipt scanned via browser camera.
+
+    The QR was already decoded client-side, so this task starts straight
+    from the FNS lookup — no image, no ``QRCodeExtractor`` step.
+
+    Args:
+        _self: Bound Celery task instance (unused, present for ``bind=True``).
+        pending_receipt_id: Primary key of the PendingReceipt to process.
+        raw_qr: Raw FNS QR string decoded in the browser.
+    """
     try:
-        receipt_data = _run_processing_pipeline(pending)
-    except Exception as exc:
-        event, message = _classify_failure(exc)
-        service.mark_failed(
-            pending_receipt=pending,
-            error_message=message,
+        pending = PendingReceipt.objects.select_related('user').get(
+            pk=pending_receipt_id,
         )
+    except PendingReceipt.DoesNotExist:
         logger.warning(
-            event,
+            'pending_receipt_missing',
             pending_receipt_id=pending_receipt_id,
-            error=str(exc),
         )
         return
 
-    service.mark_ready(
-        pending_receipt=pending,
-        receipt_data=receipt_data,
+    service = _get_pending_receipt_service()
+
+    _finalize_pipeline(
+        pending,
+        pending_receipt_id,
+        service,
+        lambda: _run_fns_pipeline_from_raw(pending, raw_qr),
     )
 
 

--- a/hasta_la_vista_money/receipts/templates/receipts/modal/instruction_modal.html
+++ b/hasta_la_vista_money/receipts/templates/receipts/modal/instruction_modal.html
@@ -32,7 +32,7 @@
                     {% translate 'Инструкция по загрузке чеков' %}
                 </h2>
                 <button type="button" @click="closeModal()" class="receipts-instruction-modal-close" aria-label="{% translate 'Закрыть' %}">
-                    <i class="bi bi-x-lg"></i>
+                    <svg class="receipts-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
                 </button>
             </div>
 

--- a/hasta_la_vista_money/receipts/templates/receipts/upload_image.html
+++ b/hasta_la_vista_money/receipts/templates/receipts/upload_image.html
@@ -19,11 +19,11 @@
             </div>
             <div class="receipts-actions">
                 <button type="button" class="receipts-chip" @click="openModal()">
-                    <i class="bi bi-info-circle"></i>
+                    <svg class="receipts-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
                     {% translate 'Инструкция' %}
                 </button>
                 <a href="{% url 'receipts:list' %}" class="receipts-button receipts-button-secondary">
-                    <i class="bi bi-arrow-left"></i>
+                    <svg class="receipts-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="19" y1="12" x2="5" y2="12"/><polyline points="12 19 5 12 12 5"/></svg>
                     {% translate 'Назад к списку' %}
                 </a>
             </div>
@@ -36,7 +36,7 @@
                         x-bind:class="{ 'is-active': activeTab === 'file' }"
                         x-on:click="selectFile()"
                         role="tab">
-                    <i class="bi bi-cloud-upload"></i>
+                    <svg class="receipts-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
                     {% translate 'Файл' %}
                 </button>
                 <button type="button"
@@ -44,7 +44,7 @@
                         x-bind:class="{ 'is-active': activeTab === 'scan' }"
                         x-on:click="selectScan()"
                         role="tab">
-                    <i class="bi bi-qr-code-scan"></i>
+                    <svg class="receipts-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><line x1="14" y1="14" x2="14" y2="21"/><line x1="21" y1="14" x2="21" y2="21"/><line x1="14" y1="17.5" x2="21" y2="17.5"/></svg>
                     {% translate 'Сканировать QR' %}
                 </button>
             </div>
@@ -55,7 +55,7 @@
 
                     <div class="receipts-section">
                         <h3>
-                            <i class="bi bi-cloud-upload"></i>
+                            <svg class="receipts-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
                             {% translate 'Файл чека' %}
                         </h3>
 
@@ -67,7 +67,7 @@
                                x-on:dragover="handleDragOver"
                                x-on:dragleave="handleDragLeave"
                                x-on:drop="handleDrop">
-                            <i class="bi bi-cloud-upload receipts-dropzone-icon"></i>
+                            <svg class="receipts-dropzone-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
                             <div class="receipts-dropzone-text">
                                 <strong>{% translate 'Перетащите изображение сюда или нажмите для выбора' %}</strong>
                                 <span>{% translate 'JPG, JPEG или PNG, до 5 МБ' %}</span>
@@ -92,7 +92,7 @@
 
                     <div class="receipts-section">
                         <h3>
-                            <i class="bi bi-wallet2"></i>
+                            <svg class="receipts-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12V7H5a2 2 0 0 1 0-4h14v4"/><path d="M3 5v14a2 2 0 0 0 2 2h16v-5"/><path d="M18 12a2 2 0 0 0 0 4h4v-4Z"/></svg>
                             {{ upload_form.account.label }}
                         </h3>
                         {{ upload_form.account }}
@@ -100,7 +100,7 @@
 
                     <div class="receipts-card-ft">
                         <p class="hint">
-                            <i class="bi bi-clock-history"></i>
+                            <svg class="receipts-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
                             {% translate 'Когда чек будет распознан, он появится в списке. Если что-то пошло не так — рядом будет показана причина.' %}
                         </p>
                         <div class="ft-actions">
@@ -108,7 +108,7 @@
                                     id="submitBtn"
                                     class="receipts-btn receipts-btn-primary"
                                     x-bind:disabled="!hasFiles">
-                                <i class="bi bi-cloud-upload"></i>
+                                <svg class="receipts-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
                                 <span>{% translate 'Поставить в обработку' %}</span>
                             </button>
                         </div>
@@ -123,7 +123,7 @@
 
                     <div class="receipts-section">
                         <h3>
-                            <i class="bi bi-wallet2"></i>
+                            <svg class="receipts-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12V7H5a2 2 0 0 1 0-4h14v4"/><path d="M3 5v14a2 2 0 0 0 2 2h16v-5"/><path d="M18 12a2 2 0 0 0 0 4h4v-4Z"/></svg>
                             {{ scan_form.account.label }}
                         </h3>
                         {{ scan_form.account }}
@@ -136,7 +136,7 @@
 
                     <div id="scan-error" class="receipts-upload-error" x-show="errorMessage" x-text="errorMessage" x-cloak></div>
                     <p class="hint" x-show="!errorMessage">
-                        <i class="bi bi-qr-code-scan"></i>
+                        <svg class="receipts-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><line x1="14" y1="14" x2="14" y2="21"/><line x1="21" y1="14" x2="21" y2="21"/><line x1="14" y1="17.5" x2="21" y2="17.5"/></svg>
                         {% translate 'Наведите камеру на QR-код чека' %}
                     </p>
                 </form>

--- a/hasta_la_vista_money/receipts/templates/receipts/upload_image.html
+++ b/hasta_la_vista_money/receipts/templates/receipts/upload_image.html
@@ -29,71 +29,118 @@
             </div>
         </header>
 
-        <div class="receipts-card receipts-upload-card" x-data="receiptUploadPage">
-            <form method="post" enctype="multipart/form-data" id="uploadForm" class="receipts-upload-form" novalidate>
-                {% csrf_token %}
+        <div class="receipts-card receipts-upload-card" x-data="receiptUploadTabs">
+            <div class="receipts-mode-tabs" role="tablist">
+                <button type="button"
+                        class="receipts-mode-tab"
+                        x-bind:class="{ 'is-active': activeTab === 'file' }"
+                        x-on:click="selectFile()"
+                        role="tab">
+                    <i class="bi bi-cloud-upload"></i>
+                    {% translate 'Файл' %}
+                </button>
+                <button type="button"
+                        class="receipts-mode-tab"
+                        x-bind:class="{ 'is-active': activeTab === 'scan' }"
+                        x-on:click="selectScan()"
+                        role="tab">
+                    <i class="bi bi-qr-code-scan"></i>
+                    {% translate 'Сканировать QR' %}
+                </button>
+            </div>
 
-                <div class="receipts-section">
-                    <h3>
-                        <i class="bi bi-cloud-upload"></i>
-                        {% translate 'Файл чека' %}
-                    </h3>
+            <div x-show="activeTab === 'file'" x-data="receiptUploadPage">
+                <form method="post" enctype="multipart/form-data" id="uploadForm" class="receipts-upload-form" novalidate>
+                    {% csrf_token %}
 
-                    <label id="upload-zone"
-                           for="file-input"
-                           class="receipts-dropzone"
-                           x-bind:class="zoneClass"
-                           x-on:dragenter="handleDragEnter"
-                           x-on:dragover="handleDragOver"
-                           x-on:dragleave="handleDragLeave"
-                           x-on:drop="handleDrop">
-                        <i class="bi bi-cloud-upload receipts-dropzone-icon"></i>
-                        <div class="receipts-dropzone-text">
-                            <strong>{% translate 'Перетащите изображение сюда или нажмите для выбора' %}</strong>
-                            <span>{% translate 'JPG, JPEG или PNG, до 5 МБ' %}</span>
-                            <span id="selected-file-name" class="receipts-dropzone-filename" x-show="hasFiles" x-cloak>
-                                <span x-text="selectedFileLabel"></span>
-                                <span class="receipts-dropzone-status">{% translate '(Файл добавлен. Отправке в обработку)' %}</span>
-                            </span>
-                        </div>
-                    </label>
-
-                    <input type="file"
-                           name="file"
-                           id="file-input"
-                           class="hidden"
-                           accept=".jpg,.jpeg,.png,image/jpeg,image/png"
-                           multiple
-                           x-ref="fileInput"
-                           x-on:change="handleInputChange">
-
-                    <div id="upload-error" class="receipts-upload-error" x-show="errorMessage" x-text="errorMessage" x-cloak></div>
-                </div>
-
-                <div class="receipts-section">
-                    <h3>
-                        <i class="bi bi-wallet2"></i>
-                        {{ form.account.label }}
-                    </h3>
-                    {{ form.account }}
-                </div>
-
-                <div class="receipts-card-ft">
-                    <p class="hint">
-                        <i class="bi bi-clock-history"></i>
-                        {% translate 'Когда чек будет распознан, он появится в списке. Если что-то пошло не так — рядом будет показана причина.' %}
-                    </p>
-                    <div class="ft-actions">
-                        <button type="submit"
-                                id="submitBtn"
-                                class="receipts-btn receipts-btn-primary"
-                                x-bind:disabled="!hasFiles">
+                    <div class="receipts-section">
+                        <h3>
                             <i class="bi bi-cloud-upload"></i>
-                            <span>{% translate 'Поставить в обработку' %}</span>
-                        </button>
+                            {% translate 'Файл чека' %}
+                        </h3>
+
+                        <label id="upload-zone"
+                               for="file-input"
+                               class="receipts-dropzone"
+                               x-bind:class="zoneClass"
+                               x-on:dragenter="handleDragEnter"
+                               x-on:dragover="handleDragOver"
+                               x-on:dragleave="handleDragLeave"
+                               x-on:drop="handleDrop">
+                            <i class="bi bi-cloud-upload receipts-dropzone-icon"></i>
+                            <div class="receipts-dropzone-text">
+                                <strong>{% translate 'Перетащите изображение сюда или нажмите для выбора' %}</strong>
+                                <span>{% translate 'JPG, JPEG или PNG, до 5 МБ' %}</span>
+                                <span id="selected-file-name" class="receipts-dropzone-filename" x-show="hasFiles" x-cloak>
+                                    <span x-text="selectedFileLabel"></span>
+                                    <span class="receipts-dropzone-status">{% translate '(Файл добавлен. Отправке в обработку)' %}</span>
+                                </span>
+                            </div>
+                        </label>
+
+                        <input type="file"
+                               name="file"
+                               id="file-input"
+                               class="hidden"
+                               accept=".jpg,.jpeg,.png,image/jpeg,image/png"
+                               multiple
+                               x-ref="fileInput"
+                               x-on:change="handleInputChange">
+
+                        <div id="upload-error" class="receipts-upload-error" x-show="errorMessage" x-text="errorMessage" x-cloak></div>
                     </div>
-                </div>
-            </form>
+
+                    <div class="receipts-section">
+                        <h3>
+                            <i class="bi bi-wallet2"></i>
+                            {{ upload_form.account.label }}
+                        </h3>
+                        {{ upload_form.account }}
+                    </div>
+
+                    <div class="receipts-card-ft">
+                        <p class="hint">
+                            <i class="bi bi-clock-history"></i>
+                            {% translate 'Когда чек будет распознан, он появится в списке. Если что-то пошло не так — рядом будет показана причина.' %}
+                        </p>
+                        <div class="ft-actions">
+                            <button type="submit"
+                                    id="submitBtn"
+                                    class="receipts-btn receipts-btn-primary"
+                                    x-bind:disabled="!hasFiles">
+                                <i class="bi bi-cloud-upload"></i>
+                                <span>{% translate 'Поставить в обработку' %}</span>
+                            </button>
+                        </div>
+                    </div>
+                </form>
+            </div>
+
+            <div x-show="activeTab === 'scan'" x-cloak class="receipts-scan-panel" x-data="receiptQRScanPage">
+                <form method="post" action="{% url 'receipts:scan_qr' %}" id="scanQrForm" x-ref="scanForm">
+                    {% csrf_token %}
+                    {{ scan_form.qr_raw }}
+
+                    <div class="receipts-section">
+                        <h3>
+                            <i class="bi bi-wallet2"></i>
+                            {{ scan_form.account.label }}
+                        </h3>
+                        {{ scan_form.account }}
+                    </div>
+
+                    <div class="receipts-scan-video-wrap">
+                        <video x-ref="video" class="receipts-scan-video" autoplay playsinline muted></video>
+                        <canvas x-ref="canvas" class="hidden"></canvas>
+                    </div>
+
+                    <div id="scan-error" class="receipts-upload-error" x-show="errorMessage" x-text="errorMessage" x-cloak></div>
+                    <p class="hint" x-show="!errorMessage">
+                        <i class="bi bi-qr-code-scan"></i>
+                        {% translate 'Наведите камеру на QR-код чека' %}
+                    </p>
+                </form>
+            </div>
         </div>
     </div>
 
@@ -104,6 +151,7 @@
 {% block extra_js %}
 <script defer nonce="{{request.csp_nonce}}" src="{% static 'js/alpine.csp.min.js' %}"></script>
 <script nonce="{{request.csp_nonce}}" src="{% static 'js/upload.js' %}"></script>
+<script nonce="{{request.csp_nonce}}" src="{% static 'js/dist/pages/receipt-qr-scan.js' %}"></script>
 {% endblock %}
 
 {% block alpine_js %}{% endblock %}

--- a/hasta_la_vista_money/receipts/tests/test_fns_integration.py
+++ b/hasta_la_vista_money/receipts/tests/test_fns_integration.py
@@ -53,6 +53,7 @@ from hasta_la_vista_money.receipts.services.pending_receipt_service import (
 from hasta_la_vista_money.receipts.tasks import (
     _run_fns_pipeline_from_raw,
     process_pending_receipt,
+    process_pending_receipt_from_qr,
 )
 from hasta_la_vista_money.users.models import User
 
@@ -448,6 +449,67 @@ class RunFnsPipelineFromRawTests(TestCase):
         )
         self.assertEqual(receipt_data['name_seller'], 'Магазин')
         self.assertIn('_fns_raw', receipt_data)
+
+
+@override_settings(
+    CACHES=TEST_CACHES,
+    FNS_INN='123456789012',
+    FNS_PASSWORD='password',  # nosec B106: test-only password
+    FNS_CLIENT_SECRET='secret',  # nosec B106: test-only secret
+    FNS_POLL_INTERVAL_SECONDS=0,
+)
+class ProcessPendingReceiptFromQRTests(TestCase):
+    """The QR-scan Celery task: no image, no QR extraction step."""
+
+    def setUp(self) -> None:
+        self.user = User.objects.create_user(
+            username='qr-task-user',
+            password='pass',  # nosec B106: test-only password
+            email='qr-task@example.com',
+        )
+        self.account = Account.objects.create(
+            user=self.user,
+            name_account='Wallet',
+            balance=1000,
+            currency='RU',
+        )
+        self.raw_qr = 't=20260525T1200&s=123.45&fn=1&i=2&fp=3&n=1'
+
+    def _create_pending(self) -> PendingReceipt:
+        return PendingReceipt.objects.create(
+            user=self.user,
+            account=self.account,
+            status=PendingReceiptStatus.PROCESSING,
+            image_hash='qr-hash-1',
+        )
+
+    def test_task_marks_ready_from_raw_qr(self) -> None:
+        pending = self._create_pending()
+        with mock.patch(
+            'hasta_la_vista_money.receipts.tasks.FNSClient.fetch_receipt',
+            return_value=_fns_payload(),
+        ):
+            process_pending_receipt_from_qr(pending.pk, self.raw_qr)
+
+        pending.refresh_from_db()
+        self.assertEqual(pending.status, PendingReceiptStatus.READY)
+        self.assertEqual(pending.receipt_data['name_seller'], 'Магазин')
+
+    def test_task_marks_failed_on_fns_error(self) -> None:
+        pending = self._create_pending()
+        with mock.patch(
+            'hasta_la_vista_money.receipts.tasks.FNSClient.fetch_receipt',
+            side_effect=FNSMalformedResponseError('bad payload'),
+        ):
+            process_pending_receipt_from_qr(pending.pk, self.raw_qr)
+
+        pending.refresh_from_db()
+        self.assertEqual(pending.status, PendingReceiptStatus.FAILED)
+        self.assertNotEqual(pending.error_message, '')
+
+    def test_task_noop_when_pending_missing(self) -> None:
+        process_pending_receipt_from_qr(999999, self.raw_qr)
+        # No exception raised — just logs and returns.
 
 
 @override_settings(

--- a/hasta_la_vista_money/receipts/tests/test_fns_integration.py
+++ b/hasta_la_vista_money/receipts/tests/test_fns_integration.py
@@ -50,7 +50,10 @@ from hasta_la_vista_money.receipts.services.pending_receipt_service import (
     PendingReceiptService,
     compute_image_hash,
 )
-from hasta_la_vista_money.receipts.tasks import process_pending_receipt
+from hasta_la_vista_money.receipts.tasks import (
+    _run_fns_pipeline_from_raw,
+    process_pending_receipt,
+)
 from hasta_la_vista_money.users.models import User
 
 TEST_CACHES = {
@@ -396,6 +399,55 @@ class FNSClientTests(TestCase):
 
         with self.assertRaises(FNSUnauthorizedError):
             self._client()._create_ticket(FNSSession('bad'), 'qr')
+
+
+@override_settings(
+    CACHES=TEST_CACHES,
+    FNS_INN='123456789012',
+    FNS_PASSWORD='password',  # nosec B106: test-only password
+    FNS_CLIENT_SECRET='secret',  # nosec B106: test-only secret
+    FNS_POLL_INTERVAL_SECONDS=0,
+)
+class RunFnsPipelineFromRawTests(TestCase):
+    """The shared FNS-lookup tail, called directly with a raw QR string."""
+
+    def setUp(self) -> None:
+        self.user = User.objects.create_user(
+            username='raw-qr-user',
+            password='pass',  # nosec B106: test-only password
+            email='raw-qr@example.com',
+        )
+        self.account = Account.objects.create(
+            user=self.user,
+            name_account='Wallet',
+            balance=1000,
+            currency='RU',
+        )
+        self.service: PendingReceiptService = (
+            ApplicationContainer().receipts.pending_receipt_service()
+        )
+
+    def test_runs_fns_lookup_without_qr_extraction(self) -> None:
+        pending = PendingReceipt.objects.create(
+            user=self.user,
+            account=self.account,
+            status=PendingReceiptStatus.PROCESSING,
+            image_hash='deadbeef',
+        )
+        with mock.patch(
+            'hasta_la_vista_money.receipts.tasks.FNSClient.fetch_receipt',
+            return_value=_fns_payload(),
+        ) as fetch_mock:
+            receipt_data = _run_fns_pipeline_from_raw(
+                pending,
+                't=20260525T1200&s=123.45&fn=1&i=2&fp=3&n=1',
+            )
+
+        fetch_mock.assert_called_once_with(
+            't=20260525T1200&s=123.45&fn=1&i=2&fp=3&n=1',
+        )
+        self.assertEqual(receipt_data['name_seller'], 'Магазин')
+        self.assertIn('_fns_raw', receipt_data)
 
 
 @override_settings(

--- a/hasta_la_vista_money/receipts/tests/test_pending_receipt_flow.py
+++ b/hasta_la_vista_money/receipts/tests/test_pending_receipt_flow.py
@@ -4,6 +4,7 @@ Covers PendingReceiptService new methods, the Celery task, and the upload /
 retry / counter views. Inference is always mocked — no network calls.
 """
 
+import hashlib
 import io
 from decimal import Decimal
 from typing import Any
@@ -512,6 +513,91 @@ class UploadImageViewTests(TestCase):
             PendingReceipt.objects.filter(user=self.user).exists(),
         )
         task_mock.delay.assert_not_called()
+
+
+class ScanQRReceiptViewTests(TestCase):
+    """The camera-scan view validates the QR, dedups, and enqueues."""
+
+    def setUp(self) -> None:
+        self.user = User.objects.create_user(
+            username='scan-user',
+            password='pass',  # nosec B106: test-only password
+            email='scan@example.com',
+        )
+        self.account = Account.objects.create(
+            user=self.user,
+            name_account='Wallet',
+            balance=1000,
+            currency='RU',
+        )
+        self.client = Client()
+        self.client.force_login(self.user)
+        self.raw_qr = 't=20260525T1200&s=123.45&fn=1&i=2&fp=3&n=1'
+
+    def test_scan_creates_processing_pending_and_dispatches(self) -> None:
+        with mock.patch(
+            'hasta_la_vista_money.receipts.views.process_pending_receipt_from_qr',
+        ) as task_mock:
+            task_mock.delay.return_value = mock.Mock(id='qr-task-id-1')
+            response = self.client.post(
+                reverse('receipts:scan_qr'),
+                {'qr_raw': self.raw_qr, 'account': self.account.pk},
+            )
+
+        self.assertRedirects(response, reverse('receipts:list'))
+        pending = PendingReceipt.objects.get(user=self.user)
+        self.assertEqual(pending.status, PendingReceiptStatus.PROCESSING)
+        self.assertFalse(pending.image_file)
+        self.assertEqual(pending.task_id, 'qr-task-id-1')
+        task_mock.delay.assert_called_once_with(pending.pk, self.raw_qr)
+
+    def test_scan_rejects_invalid_qr_string(self) -> None:
+        with mock.patch(
+            'hasta_la_vista_money.receipts.views.process_pending_receipt_from_qr',
+        ) as task_mock:
+            response = self.client.post(
+                reverse('receipts:scan_qr'),
+                {'qr_raw': 'not-a-fns-qr', 'account': self.account.pk},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(
+            PendingReceipt.objects.filter(user=self.user).exists(),
+        )
+        task_mock.delay.assert_not_called()
+
+    def test_scan_rejects_duplicate_qr(self) -> None:
+        image_hash = hashlib.sha256(self.raw_qr.encode()).hexdigest()
+        PendingReceipt.objects.create(
+            user=self.user,
+            account=self.account,
+            status=PendingReceiptStatus.PROCESSING,
+            image_hash=image_hash,
+        )
+
+        with mock.patch(
+            'hasta_la_vista_money.receipts.views.process_pending_receipt_from_qr',
+        ) as task_mock:
+            response = self.client.post(
+                reverse('receipts:scan_qr'),
+                {'qr_raw': self.raw_qr, 'account': self.account.pk},
+            )
+
+        self.assertRedirects(response, reverse('receipts:list'))
+        self.assertEqual(
+            PendingReceipt.objects.filter(user=self.user).count(),
+            1,
+        )
+        task_mock.delay.assert_not_called()
+
+    def test_scan_requires_login(self) -> None:
+        self.client.logout()
+        response = self.client.post(
+            reverse('receipts:scan_qr'),
+            {'qr_raw': self.raw_qr, 'account': self.account.pk},
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(PendingReceipt.objects.exists())
 
 
 class PendingCounterViewTests(TestCase):

--- a/hasta_la_vista_money/receipts/tests/test_pending_receipt_flow.py
+++ b/hasta_la_vista_money/receipts/tests/test_pending_receipt_flow.py
@@ -127,6 +127,35 @@ class PendingReceiptServiceHashTests(TestCase):
         assert match is not None
         self.assertEqual(match.kind, 'pending')
 
+    def test_create_processing_job_from_qr_has_no_image_file(self) -> None:
+        pending = self.service.create_processing_job_from_qr(
+            user=self.user,
+            account=self.account,
+            image_hash='a' * 64,
+        )
+
+        self.assertFalse(pending.image_file)
+        self.assertEqual(pending.image_hash, 'a' * 64)
+        self.assertEqual(pending.status, PendingReceiptStatus.PROCESSING)
+
+    def test_create_processing_job_from_qr_is_deduplicated_like_photos(
+        self,
+    ) -> None:
+        image_hash = 'b' * 64
+        self.service.create_processing_job_from_qr(
+            user=self.user,
+            account=self.account,
+            image_hash=image_hash,
+        )
+
+        match = self.service.find_duplicate(
+            user=self.user,
+            image_hash=image_hash,
+        )
+        self.assertIsNotNone(match)
+        assert match is not None
+        self.assertEqual(match.kind, 'pending')
+
     def test_failed_pending_does_not_block_reupload(self) -> None:
         upload = SimpleUploadedFile(
             'a.jpg',

--- a/hasta_la_vista_money/receipts/urls.py
+++ b/hasta_la_vista_money/receipts/urls.py
@@ -22,6 +22,7 @@ from hasta_la_vista_money.receipts.views import (
     ReceiptUpdateView,
     ReceiptView,
     ReviewPendingReceiptView,
+    ScanQRReceiptView,
     SellerCreateView,
     SellerUpdateView,
     UploadImageView,
@@ -83,6 +84,11 @@ urlpatterns = [
         'upload/',
         UploadImageView.as_view(),
         name='upload',
+    ),
+    path(
+        'scan-qr/',
+        ScanQRReceiptView.as_view(),
+        name='scan_qr',
     ),
     path(
         'review/<int:pk>/',

--- a/hasta_la_vista_money/receipts/views/__init__.py
+++ b/hasta_la_vista_money/receipts/views/__init__.py
@@ -1,4 +1,7 @@
-from hasta_la_vista_money.receipts.tasks import process_pending_receipt
+from hasta_la_vista_money.receipts.tasks import (
+    process_pending_receipt,
+    process_pending_receipt_from_qr,
+)
 from hasta_la_vista_money.receipts.views.list import (
     ProductByMonthView,
     ReceiptView,
@@ -36,4 +39,5 @@ __all__ = [
     'SellerUpdateView',
     'UploadImageView',
     'process_pending_receipt',
+    'process_pending_receipt_from_qr',
 ]

--- a/hasta_la_vista_money/receipts/views/__init__.py
+++ b/hasta_la_vista_money/receipts/views/__init__.py
@@ -22,7 +22,10 @@ from hasta_la_vista_money.receipts.views.seller import (
     SellerCreateView,
     SellerUpdateView,
 )
-from hasta_la_vista_money.receipts.views.upload import UploadImageView
+from hasta_la_vista_money.receipts.views.upload import (
+    ScanQRReceiptView,
+    UploadImageView,
+)
 
 __all__ = [
     'PendingReceiptCounterView',
@@ -35,6 +38,7 @@ __all__ = [
     'ReceiptUpdateView',
     'ReceiptView',
     'ReviewPendingReceiptView',
+    'ScanQRReceiptView',
     'SellerCreateView',
     'SellerUpdateView',
     'UploadImageView',

--- a/hasta_la_vista_money/receipts/views/upload.py
+++ b/hasta_la_vista_money/receipts/views/upload.py
@@ -1,3 +1,4 @@
+import hashlib
 import sys
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
@@ -15,6 +16,7 @@ from django.views.generic import (
 from hasta_la_vista_money import constants
 from hasta_la_vista_money.core.mixins.base import FormErrorHandlingMixin
 from hasta_la_vista_money.receipts.forms import (
+    ScanQRForm,
     UploadImageForm,
 )
 from hasta_la_vista_money.receipts.services.pending_receipt_service import (
@@ -54,6 +56,15 @@ class UploadImageView(
         kwargs = super().get_form_kwargs()
         kwargs['user'] = self.request.user
         return kwargs
+
+    def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
+        context = super().get_context_data(**kwargs)
+        context['upload_form'] = context.pop('form')
+        context.setdefault(
+            'scan_form',
+            ScanQRForm(user=self.request.user),
+        )
+        return context
 
     def form_valid(self, form: UploadImageForm) -> HttpResponse:
         request = cast('RequestWithContainer', self.request)
@@ -136,3 +147,89 @@ class UploadImageView(
     def _get_uploaded_files(self) -> list[Any]:
         """Extract all uploaded files from request."""
         return list(self.request.FILES.getlist('file'))
+
+
+class ScanQRReceiptView(
+    LoginRequiredMixin,
+    FormView[ScanQRForm],
+    FormErrorHandlingMixin,
+):
+    """Accept a QR string decoded in-browser and enqueue an FNS lookup.
+
+    Mirrors UploadImageView but skips the image upload + pyzbar decode step
+    entirely: the QR is already decoded client-side (camera scan), so only
+    the raw QR string and target account are submitted.
+    """
+
+    template_name = 'receipts/upload_image.html'
+    form_class: type[ScanQRForm] = ScanQRForm
+    success_url: ClassVar[str] = cast('str', reverse_lazy('receipts:list'))  # type: ignore[misc]
+
+    def get_form_kwargs(self) -> dict[str, Any]:
+        kwargs = super().get_form_kwargs()
+        kwargs['user'] = self.request.user
+        return kwargs
+
+    def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
+        context = super().get_context_data(**kwargs)
+        context['scan_form'] = context.pop('form')
+        context.setdefault(
+            'upload_form',
+            UploadImageForm(user=self.request.user),
+        )
+        return context
+
+    def form_valid(self, form: ScanQRForm) -> HttpResponse:
+        request = cast('RequestWithContainer', self.request)
+        user = cast('User', request.user)
+        account = form.cleaned_data['account']
+        qr_raw = form.cleaned_data['qr_raw']
+        image_hash = hashlib.sha256(qr_raw.encode()).hexdigest()
+
+        pending_receipt_service = (
+            request.container.receipts.pending_receipt_service()
+        )
+
+        duplicate = pending_receipt_service.find_duplicate(
+            user=user,
+            image_hash=image_hash,
+        )
+        if duplicate is not None:
+            messages.warning(request, _('Этот чек уже загружен.'))
+            return redirect('receipts:list')
+
+        try:
+            pending_receipt = (
+                pending_receipt_service.create_processing_job_from_qr(
+                    user=user,
+                    account=account,
+                    image_hash=image_hash,
+                )
+            )
+        except Exception as exc:
+            logger.exception(
+                'Error queuing scanned receipt for processing',
+                error=exc,
+            )
+            return self.handle_form_error_with_message(
+                form,
+                exc,
+                constants.ERROR_PROCESSING_RECEIPT,
+            )
+
+        async_result = _views_module().process_pending_receipt_from_qr.delay(
+            pending_receipt.pk,
+            qr_raw,
+        )
+        pending_receipt_service.attach_task_id(
+            pending_receipt=pending_receipt,
+            task_id=async_result.id,
+        )
+        messages.success(
+            request,
+            _(
+                'Чек поставлен в обработку. Когда распознавание '
+                'завершится, он появится в списке.',
+            ),
+        )
+        return redirect('receipts:list')

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
-  "name": "hasta-la-vista-money",
+  "name": "receipt-qr-camera-scan",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "dependencies": {
         "driver.js": "^1.4.0",
-        "flatpickr": "^4.6.13"
+        "flatpickr": "^4.6.13",
+        "jsqr": "^1.4.0"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -1163,6 +1164,12 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jsqr": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsqr/-/jsqr-1.4.0.tgz",
+      "integrity": "sha512-dxLob7q65Xg2DvstYkRpkYtmKm2sPJ9oFhrhmudT1dZvNFFTlroai3AWSpLey/w5vMcLBXRgOJsbXpdN9HzU/A==",
+      "license": "Apache-2.0"
     },
     "node_modules/keyv": {
       "version": "4.5.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "receipt-qr-camera-scan",
+  "name": "hastalavistamoney",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "dependencies": {
     "driver.js": "^1.4.0",
-    "flatpickr": "^4.6.13"
+    "flatpickr": "^4.6.13",
+    "jsqr": "^1.4.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/static/js/pages/receipt-qr-scan.js
+++ b/static/js/pages/receipt-qr-scan.js
@@ -1,0 +1,116 @@
+import jsQR from 'jsqr';
+
+const SCAN_INTERVAL_MS = 200;
+const CAMERA_UNAVAILABLE_MESSAGE = 'Камера недоступна в этом браузере.';
+const CAMERA_DENIED_MESSAGE = 'Нет доступа к камере. Используйте загрузку файла.';
+
+function registerReceiptUploadTabs(Alpine) {
+    Alpine.data('receiptUploadTabs', function () {
+        return {
+            activeTab: 'file',
+
+            selectFile() {
+                this.activeTab = 'file';
+                document.dispatchEvent(new CustomEvent('receipt-scan:deactivate'));
+            },
+
+            selectScan() {
+                this.activeTab = 'scan';
+                document.dispatchEvent(new CustomEvent('receipt-scan:activate'));
+            },
+        };
+    });
+}
+
+function registerReceiptQRScanPage(Alpine) {
+    Alpine.data('receiptQRScanPage', function () {
+        return {
+            errorMessage: '',
+            stream: null,
+            scanTimer: null,
+
+            init() {
+                document.addEventListener('receipt-scan:activate', this.start.bind(this));
+                document.addEventListener('receipt-scan:deactivate', this.stop.bind(this));
+                window.addEventListener('beforeunload', this.stop.bind(this));
+            },
+
+            async start() {
+                this.errorMessage = '';
+                if (this.stream) {
+                    return;
+                }
+                if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
+                    this.errorMessage = CAMERA_UNAVAILABLE_MESSAGE;
+                    return;
+                }
+                try {
+                    this.stream = await navigator.mediaDevices.getUserMedia({
+                        video: { facingMode: 'environment' },
+                    });
+                } catch (_error) {
+                    this.errorMessage = CAMERA_DENIED_MESSAGE;
+                    return;
+                }
+                const video = this.$refs.video;
+                if (!video) {
+                    this.stop();
+                    return;
+                }
+                video.srcObject = this.stream;
+                await video.play();
+                this.scanTimer = window.setInterval(this.scanFrame.bind(this), SCAN_INTERVAL_MS);
+            },
+
+            scanFrame() {
+                const video = this.$refs.video;
+                const canvas = this.$refs.canvas;
+                if (!video || !canvas || video.readyState !== video.HAVE_ENOUGH_DATA) {
+                    return;
+                }
+                canvas.width = video.videoWidth;
+                canvas.height = video.videoHeight;
+                const context = canvas.getContext('2d');
+                context.drawImage(video, 0, 0, canvas.width, canvas.height);
+                const imageData = context.getImageData(0, 0, canvas.width, canvas.height);
+                const decoded = jsQR(imageData.data, imageData.width, imageData.height);
+                if (decoded && decoded.data) {
+                    this.submitDecoded(decoded.data);
+                }
+            },
+
+            submitDecoded(rawValue) {
+                this.stop();
+                const form = this.$refs.scanForm;
+                const qrInput = form ? form.querySelector('[name="qr_raw"]') : null;
+                if (qrInput) {
+                    qrInput.value = rawValue;
+                }
+                if (form) {
+                    form.submit();
+                }
+            },
+
+            stop() {
+                if (this.scanTimer) {
+                    window.clearInterval(this.scanTimer);
+                    this.scanTimer = null;
+                }
+                if (this.stream) {
+                    this.stream.getTracks().forEach(track => track.stop());
+                    this.stream = null;
+                }
+            },
+        };
+    });
+}
+
+if (window.Alpine) {
+    registerReceiptUploadTabs(window.Alpine);
+    registerReceiptQRScanPage(window.Alpine);
+} else {
+    document.addEventListener('alpine:init', function () {
+        registerReceiptUploadTabs(window.Alpine);
+        registerReceiptQRScanPage(window.Alpine);
+    });
+}


### PR DESCRIPTION
## Summary
- Adds an in-browser camera QR scanner (jsQR) as a mobile-only tab on the receipt upload page, alongside the existing file dropzone.
- A decoded QR is posted directly to a new `receipts:scan_qr` endpoint, skipping image upload and the server-side `pyzbar` decode step entirely — processing starts straight from the FNS lookup.
- Dedup reuses the existing `PendingReceipt.image_hash` mechanism (`sha256` of the raw QR string instead of the image bytes), so no schema migration is needed.
- Camera/permission failures show an inline error with a fallback to the file tab; the scan tab itself is hidden above a 768px viewport (CSS-only, no capability detection).

## Implementation
- `tasks.py`: split `_run_fns_pipeline` into a reusable `_run_fns_pipeline_from_raw` tail, extracted a shared `_finalize_pipeline` helper, added `process_pending_receipt_from_qr` Celery task.
- `pending_receipt_service.py` / `protocols/services.py`: added `create_processing_job_from_qr`.
- `forms.py` / `views/upload.py` / `urls.py`: added `ScanQRForm` + `ScanQRReceiptView`.
- `static/js/pages/receipt-qr-scan.js`: new esbuild entry bundling `jsQR`, camera lifecycle, and tab-switch Alpine components.
- `upload_image.html` / `receipts.css`: mobile-only tab UI wired to both forms.

## Test plan
- [x] `uv run python manage.py test` — 972 tests passing (full suite, including new `RunFnsPipelineFromRawTests`, `ProcessPendingReceiptFromQRTests`, `PendingReceiptServiceHashTests` additions, `ScanQRReceiptViewTests`)
- [x] `npm run lint:js` / `npm run build:js` — clean
- [x] Verified rendered template contains scan-tab markup via a throwaway Django test client check
- [ ] Manual mobile-browser verification (camera permission flow, live decode) — not performed in this headless session, recommend testing on a real device before merge