### PR TITLE
fix(finance_account): make balance updates atomic

### DIFF
--- a/core/protocols/services.py
+++ b/core/protocols/services.py
@@ -43,9 +43,7 @@ class AccountServiceProtocol(Protocol):
         """
         ...
 
-    def get_account_by_id(
-        self, account_id: int, user: User
-    ) -> Account | None:
+    def get_account_by_id(self, account_id: int, user: User) -> Account | None:
         """Get account by ID for a user.
 
         Args:
@@ -107,9 +105,7 @@ class AccountServiceProtocol(Protocol):
         """
         ...
 
-    def apply_receipt_spend(
-        self, account: Account, amount: Decimal
-    ) -> Account:
+    def apply_receipt_spend(self, account: Account, amount: Decimal) -> Account:
         """Apply spending to account balance.
 
         Args:
@@ -121,9 +117,7 @@ class AccountServiceProtocol(Protocol):
         """
         ...
 
-    def refund_to_account(
-        self, account: Account, amount: Decimal
-    ) -> Account:
+    def refund_to_account(self, account: Account, amount: Decimal) -> Account:
         """Refund amount to account balance.
 
         Args:
@@ -133,6 +127,13 @@ class AccountServiceProtocol(Protocol):
         Returns:
             Updated Account instance.
         """
+        ...
+
+    def apply_account_deltas(
+        self,
+        deltas: dict[int, Decimal],
+    ) -> dict[int, Account]:
+        """Apply signed deltas to accounts atomically."""
         ...
 
     def reconcile_account_balances(

--- a/hasta_la_vista_money/finance_account/services/account_service.py
+++ b/hasta_la_vista_money/finance_account/services/account_service.py
@@ -231,6 +231,13 @@ class AccountService:
         """
         return self.balance_service.refund_to_account(account, amount)
 
+    def apply_account_deltas(
+        self,
+        deltas: dict[int, Decimal],
+    ) -> dict[int, Account]:
+        """Apply signed balance deltas atomically."""
+        return self.balance_service.apply_account_deltas(deltas)
+
     def reconcile_account_balances(
         self,
         command: BalanceReconcileCommand,

--- a/hasta_la_vista_money/finance_account/services/balance_service.py
+++ b/hasta_la_vista_money/finance_account/services/balance_service.py
@@ -2,6 +2,8 @@
 
 from decimal import Decimal
 
+from django.db import transaction
+
 from hasta_la_vista_money.finance_account.models import Account
 from hasta_la_vista_money.finance_account.services.types import (
     BalanceReconcileCommand,
@@ -34,10 +36,7 @@ class BalanceService:
                 insufficient funds.
         """
         validate_positive_amount(amount)
-        validate_account_balance(account, amount)
-        account.balance -= amount
-        account.save()
-        return account
+        return self.apply_account_deltas({account.pk: -amount})[account.pk]
 
     def refund_to_account(self, account: Account, amount: Decimal) -> Account:
         """Return money to account balance with validation.
@@ -53,9 +52,7 @@ class BalanceService:
             ValidationError: If amount is invalid.
         """
         validate_positive_amount(amount)
-        account.balance += amount
-        account.save()
-        return account
+        return self.apply_account_deltas({account.pk: amount})[account.pk]
 
     def _adjust_balance_on_same_account(
         self,
@@ -122,9 +119,10 @@ class BalanceService:
         Returns:
             Updated Account instance.
         """
-        account.balance += delta
-        account.save(update_fields=['balance'])
-        return account
+        if delta == 0:
+            account.refresh_from_db(fields=['balance'])
+            return account
+        return self.apply_account_deltas({account.pk: delta})[account.pk]
 
     def reconcile_account_balances(
         self,
@@ -142,19 +140,40 @@ class BalanceService:
             old_total_sum: Total amount before change.
             new_total_sum: Total amount after change.
         """
-        if self._should_adjust_same_account(
-            command.old_account,
-            command.new_account,
-        ):
-            self._adjust_balance_on_same_account(
-                command.old_account,
-                command.old_total_sum,
-                command.new_total_sum,
-            )
-        else:
-            self._adjust_balance_on_account_change(
-                command.old_account,
-                command.new_account,
-                command.old_total_sum,
-                command.new_total_sum,
-            )
+        deltas = {command.old_account.pk: command.old_total_sum}
+        deltas[command.new_account.pk] = (
+            deltas.get(command.new_account.pk, 0) - command.new_total_sum
+        )
+        self.apply_account_deltas(deltas)
+
+    @transaction.atomic
+    def apply_account_deltas(
+        self,
+        deltas: dict[int, Decimal],
+    ) -> dict[int, Account]:
+        """Apply signed deltas while locking accounts in a stable order."""
+        effective_deltas = {
+            account_id: delta
+            for account_id, delta in deltas.items()
+            if delta != 0
+        }
+        if not effective_deltas:
+            return {}
+
+        accounts = list(
+            Account.objects.select_for_update()
+            .filter(pk__in=effective_deltas)
+            .order_by('pk'),
+        )
+        if len(accounts) != len(effective_deltas):
+            raise Account.DoesNotExist
+
+        result: dict[int, Account] = {}
+        for locked_account in accounts:
+            delta = effective_deltas[locked_account.pk]
+            if delta < 0:
+                validate_account_balance(locked_account, abs(delta))
+            locked_account.balance += delta
+            locked_account.save(update_fields=['balance', 'updated_at'])
+            result[locked_account.pk] = locked_account
+        return result

--- a/hasta_la_vista_money/finance_account/services/transfer_service.py
+++ b/hasta_la_vista_money/finance_account/services/transfer_service.py
@@ -74,9 +74,19 @@ class TransferService:
         """
         validate_positive_amount(amount)
         validate_different_accounts(from_account, to_account)
+        if from_account.user_id != user.pk or to_account.user_id != user.pk:
+            raise PermissionDenied(
+                _('У вас нет прав на операции с этими счетами.'),
+            )
 
-        self._balance_service.apply_receipt_spend(from_account, amount)
-        self._balance_service.refund_to_account(to_account, amount)
+        locked_accounts = self._balance_service.apply_account_deltas(
+            {
+                from_account.pk: -amount,
+                to_account.pk: amount,
+            },
+        )
+        from_account = locked_accounts[from_account.pk]
+        to_account = locked_accounts[to_account.pk]
 
         return self.transfer_money_log_repository.create_log(
             user=user,
@@ -120,12 +130,10 @@ class TransferService:
                 ),
             )
 
-        self._balance_service.refund_to_account(
-            transfer_log.from_account,
-            transfer_log.amount,
-        )
-        self._balance_service.apply_receipt_spend(
-            transfer_log.to_account,
-            transfer_log.amount,
+        self._balance_service.apply_account_deltas(
+            {
+                transfer_log.from_account.pk: transfer_log.amount,
+                transfer_log.to_account.pk: -transfer_log.amount,
+            },
         )
         self.transfer_money_log_repository.delete_log(transfer_log)

--- a/hasta_la_vista_money/finance_account/tests/test_services.py
+++ b/hasta_la_vista_money/finance_account/tests/test_services.py
@@ -19,6 +19,9 @@ from hasta_la_vista_money.finance_account.models import (
     Account,
     TransferMoneyLog,
 )
+from hasta_la_vista_money.finance_account.services.balance_service import (
+    BalanceService,
+)
 from hasta_la_vista_money.users.factories import UserFactory
 from hasta_la_vista_money.users.models import FamilyGroupMembership
 
@@ -63,6 +66,20 @@ class TestAccountServices(TestCase):
         self.assertIn(self.account1, accounts)
         self.assertIn(self.account2, accounts)
         self.assertNotIn(self.account3, accounts)
+
+    def test_balance_change_ignores_stale_account_value(self) -> None:
+        stale_account = Account.objects.get(pk=self.account1.pk)
+        Account.objects.filter(pk=self.account1.pk).update(
+            balance=Decimal('1250.00'),
+        )
+
+        BalanceService().apply_receipt_spend(
+            stale_account,
+            Decimal('100.00'),
+        )
+
+        self.account1.refresh_from_db()
+        self.assertEqual(self.account1.balance, Decimal('1150.00'))
 
     def test_get_accounts_for_user_or_group_my(self) -> None:
         """Test get_accounts_for_user_or_group with 'my' group_id."""

--- a/hasta_la_vista_money/receipts/apis.py
+++ b/hasta_la_vista_money/receipts/apis.py
@@ -10,7 +10,6 @@ from typing import TYPE_CHECKING, Any, cast
 
 import structlog
 from django.core.exceptions import ValidationError as DjangoValidationError
-from django.db import transaction
 from django.db.models import QuerySet
 from drf_spectacular.openapi import AutoSchema
 from drf_spectacular.utils import (
@@ -20,7 +19,11 @@ from drf_spectacular.utils import (
 )
 from rest_framework import status
 from rest_framework.exceptions import NotFound, PermissionDenied
-from rest_framework.generics import ListCreateAPIView, RetrieveAPIView
+from rest_framework.generics import (
+    ListAPIView,
+    ListCreateAPIView,
+    RetrieveAPIView,
+)
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -63,7 +66,7 @@ logger = structlog.get_logger(__name__)
     summary='Список чеков',
     description='Получить список всех чеков текущего пользователя',
 )
-class ReceiptListAPIView(ListCreateAPIView[Receipt]):
+class ReceiptListAPIView(ListAPIView[Receipt]):
     """API view for listing and creating receipts.
 
     Provides endpoints for:
@@ -392,7 +395,8 @@ class ReceiptCreateAPIView(ListCreateAPIView[Receipt]):
         mapper = self._get_mapper()
 
         # Validate user and account
-        user_id = request_data.get('user')
+        request_user = cast('User', self.request.user)
+        user_id = request_user.pk
         account_id = request_data.get('finance_account')
         validation_result = validator.validate_user_and_account(
             user_id,
@@ -649,17 +653,11 @@ class ReceiptDeleteAPIView(APIView):
                 'You do not have permission to delete this receipt',
             )
 
-        with transaction.atomic():
-            request_with_container = cast('RequestWithContainer', request)
-            container = request_with_container.container
-            account_service = container.finance_account.account_service()
-
-            account_service.refund_to_account(
-                receipt.account,
-                receipt.total_sum,
-            )
-
-            receipt.delete()
+        request_with_container = cast('RequestWithContainer', request)
+        deleter = (
+            request_with_container.container.receipts.receipt_deleter_service()
+        )
+        deleter.delete_receipt(user=user, receipt=receipt)
 
         return Response(status=status.HTTP_204_NO_CONTENT)
 

--- a/hasta_la_vista_money/receipts/services/receipt_creator.py
+++ b/hasta_la_vista_money/receipts/services/receipt_creator.py
@@ -25,6 +25,22 @@ if TYPE_CHECKING:
     )
 
 
+def receipt_balance_delta(
+    operation_type: int | str | None,
+    amount: Decimal,
+) -> Decimal:
+    """Return the account balance effect of an FNS receipt operation."""
+    try:
+        normalized_type = int(operation_type)  # type: ignore[arg-type]
+    except (TypeError, ValueError) as error:
+        raise ValueError('Unsupported receipt operation type') from error
+    if normalized_type not in {1, 2, 3, 4}:
+        raise ValueError('Unsupported receipt operation type')
+    if normalized_type in {2, 3}:
+        return amount
+    return -amount
+
+
 class ReceiptCreatorService:
     """Service for creating receipts with products.
 
@@ -83,17 +99,16 @@ class ReceiptCreatorService:
         """
 
         account_balance = self.account_repository.get_by_id(account.pk)
-        is_refund = receipt_data.operation_type in {2, 4}
-        if is_refund:
-            self.account_service.refund_to_account(
-                account_balance,
-                receipt_data.total_sum,
-            )
-        else:
-            self.account_service.apply_receipt_spend(
-                account_balance,
-                receipt_data.total_sum,
-            )
+        if account_balance.user_id != user.pk:
+            raise ValueError('Account does not belong to user')
+        self.account_service.apply_account_deltas(
+            {
+                account_balance.pk: receipt_balance_delta(
+                    receipt_data.operation_type,
+                    receipt_data.total_sum,
+                ),
+            },
+        )
 
         if seller_id is not None:
             try:
@@ -165,11 +180,14 @@ class ReceiptCreatorService:
         if account_balance.user != user:
             return None
 
-        is_refund = receipt.operation_type in {2, 4}
-        if is_refund:
-            self.account_service.refund_to_account(account_balance, total_sum)
-        else:
-            self.account_service.apply_receipt_spend(account_balance, total_sum)
+        self.account_service.apply_account_deltas(
+            {
+                account_balance.pk: receipt_balance_delta(
+                    receipt.operation_type,
+                    total_sum,
+                ),
+            },
+        )
 
         receipt.user = user
         receipt.seller = seller

--- a/hasta_la_vista_money/receipts/services/receipt_deleter.py
+++ b/hasta_la_vista_money/receipts/services/receipt_deleter.py
@@ -2,6 +2,9 @@ from django.db import transaction
 
 from core.protocols.services import AccountServiceProtocol
 from hasta_la_vista_money.receipts.models import Receipt
+from hasta_la_vista_money.receipts.services.receipt_creator import (
+    receipt_balance_delta,
+)
 from hasta_la_vista_money.users.models import User
 
 
@@ -14,17 +17,17 @@ class ReceiptDeleterService:
     @transaction.atomic
     def delete_receipt(self, *, user: User, receipt: Receipt) -> None:
         """Delete receipt and reverse its balance effect."""
-        is_refund = receipt.operation_type in {2, 4}
-        if is_refund:
-            self.account_service.apply_receipt_spend(
-                receipt.account,
-                receipt.total_sum,
-            )
-        else:
-            self.account_service.refund_to_account(
-                receipt.account,
-                receipt.total_sum,
-            )
+        receipt = Receipt.objects.select_for_update().get(pk=receipt.pk)
+        if receipt.user_id != user.pk:
+            raise Receipt.DoesNotExist
+        self.account_service.apply_account_deltas(
+            {
+                receipt.account_id: -receipt_balance_delta(
+                    receipt.operation_type,
+                    receipt.total_sum,
+                ),
+            },
+        )
 
         for product in receipt.product.all():
             product.delete()

--- a/hasta_la_vista_money/receipts/services/receipt_updater.py
+++ b/hasta_la_vista_money/receipts/services/receipt_updater.py
@@ -10,11 +10,11 @@ from core.repositories.protocols import (
     ReceiptRepositoryProtocol,
     SellerRepositoryProtocol,
 )
-from hasta_la_vista_money.finance_account.services.types import (
-    BalanceReconcileCommand,
-)
 from hasta_la_vista_money.receipts.forms import ProductForm, ReceiptForm
 from hasta_la_vista_money.receipts.models import Receipt
+from hasta_la_vista_money.receipts.services.receipt_creator import (
+    receipt_balance_delta,
+)
 from hasta_la_vista_money.users.models import User
 
 if TYPE_CHECKING:
@@ -75,9 +75,25 @@ class ReceiptUpdaterService:
         Returns:
             Updated Receipt instance.
         """
+        receipt = Receipt.objects.select_for_update().get(pk=receipt.pk)
         old_total_sum = receipt.total_sum
-        old_account = receipt.account
-        receipt = form.save()
+        old_account_id = receipt.account_id
+        old_operation_type = receipt.operation_type
+        form.instance = receipt
+        for field_name in (
+            'seller',
+            'account',
+            'receipt_date',
+            'number_receipt',
+            'operation_type',
+            'nds10',
+            'nds20',
+        ):
+            setattr(receipt, field_name, form.cleaned_data[field_name])
+        if receipt.operation_type is None:
+            raise ValueError('Receipt operation type is required')
+        receipt.operation_type = int(receipt.operation_type)
+        receipt.save()
         receipt.product.clear()
         new_total_sum = Decimal('0.00')
 
@@ -109,16 +125,14 @@ class ReceiptUpdaterService:
         receipt.total_sum = new_total_sum
         receipt.save()
 
-        new_account = receipt.account
-
-        old_account_obj = self.account_repository.get_by_id(old_account.pk)
-        new_account_obj = self.account_repository.get_by_id(new_account.pk)
-        self.account_service.reconcile_account_balances(
-            BalanceReconcileCommand(
-                old_account=old_account_obj,
-                new_account=new_account_obj,
-                old_total_sum=old_total_sum,
-                new_total_sum=new_total_sum,
-            ),
+        old_delta = receipt_balance_delta(old_operation_type, old_total_sum)
+        new_delta = receipt_balance_delta(
+            receipt.operation_type,
+            new_total_sum,
         )
+        deltas = {old_account_id: -old_delta}
+        deltas[receipt.account_id] = (
+            deltas.get(receipt.account_id, 0) + new_delta
+        )
+        self.account_service.apply_account_deltas(deltas)
         return receipt

--- a/hasta_la_vista_money/receipts/tests/test_receipt_update.py
+++ b/hasta_la_vista_money/receipts/tests/test_receipt_update.py
@@ -7,8 +7,34 @@ from django.urls import reverse
 from hasta_la_vista_money.constants import RECEIPT_OPERATION_PURCHASE
 from hasta_la_vista_money.finance_account.models import Account
 from hasta_la_vista_money.receipts.models import Product, Receipt, Seller
+from hasta_la_vista_money.receipts.services.receipt_creator import (
+    receipt_balance_delta,
+)
 
 User = get_user_model()
+
+
+class ReceiptBalanceDeltaTest(TestCase):
+    def test_all_fns_operation_directions(self) -> None:
+        cases = (
+            (1, Decimal('-100.00')),
+            (2, Decimal('100.00')),
+            (3, Decimal('100.00')),
+            (4, Decimal('-100.00')),
+        )
+        for operation_type, expected in cases:
+            with self.subTest(operation_type=operation_type):
+                self.assertEqual(
+                    receipt_balance_delta(
+                        operation_type,
+                        Decimal('100.00'),
+                    ),
+                    expected,
+                )
+
+    def test_unknown_operation_type_is_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            receipt_balance_delta(None, Decimal('100.00'))
 
 
 class ReceiptUpdateViewTest(TestCase):

--- a/hasta_la_vista_money/receipts/tests/test_views_models_apis.py
+++ b/hasta_la_vista_money/receipts/tests/test_views_models_apis.py
@@ -1226,10 +1226,9 @@ class TestReviewPendingReceiptView(TestCase):
         self.assertEqual(response.status_code, 302)
         self.assertRedirects(response, '/receipts/')
 
-        self.mock_account_service.apply_receipt_spend.assert_called_once()
-        call_args = self.mock_account_service.apply_receipt_spend.call_args
-        self.assertEqual(call_args[0][0].pk, self.account.pk)
-        self.assertEqual(call_args[0][1], Decimal('150.00'))
+        self.mock_account_service.apply_account_deltas.assert_called_once_with(
+            {self.account.pk: Decimal('-150.00')},
+        )
 
         self.assertFalse(
             PendingReceipt.objects.filter(pk=self.pending_receipt.pk).exists(),
@@ -1323,7 +1322,7 @@ class TestReviewPendingReceiptView(TestCase):
 
     def test_review_pending_receipt_view_insufficient_funds(self) -> None:
         self.client.force_login(self.user)
-        self.mock_account_service.apply_receipt_spend.side_effect = (
+        self.mock_account_service.apply_account_deltas.side_effect = (
             ValidationError('Недостаточно средств на счете')
         )
         url = reverse_lazy(

--- a/hasta_la_vista_money/transactions/repositories/transaction_repository.py
+++ b/hasta_la_vista_money/transactions/repositories/transaction_repository.py
@@ -24,6 +24,14 @@ class TransactionRepository:
         """Return the transaction with the given primary key."""
         return Transaction.objects.get(pk=transaction_id)
 
+    def get_by_id_for_update(self, transaction_id: int) -> Transaction:
+        """Return and lock a transaction for mutation."""
+        return (
+            Transaction.objects.select_for_update()
+            .select_related('account', 'category', 'user')
+            .get(pk=transaction_id)
+        )
+
     def get_by_user(
         self,
         user: User,

--- a/hasta_la_vista_money/transactions/services/transaction_ops.py
+++ b/hasta_la_vista_money/transactions/services/transaction_ops.py
@@ -73,6 +73,19 @@ class TransactionService:
                 ),
             )
 
+    @staticmethod
+    def _validate_category_owner(user: User, category: Category) -> None:
+        if category.user_id != user.pk:
+            raise PermissionDenied(
+                _('У вас нет прав на использование этой категории.'),
+            )
+
+    @staticmethod
+    def _balance_delta(amount: Decimal, type_value: str) -> Decimal:
+        if type_value == TransactionType.INCOME:
+            return amount
+        return -amount
+
     def _apply_balance_for_create(
         self,
         account: Account,
@@ -105,6 +118,7 @@ class TransactionService:
             command.type_value,
             command.category,
         )
+        self._validate_category_owner(command.user, command.category)
 
         with db_transaction.atomic():
             new_transaction = self.transaction_repository.create_transaction(
@@ -136,23 +150,30 @@ class TransactionService:
             command.type_value,
             command.category,
         )
+        self._validate_category_owner(command.user, command.category)
 
         with db_transaction.atomic():
-            old_account = command.transaction_obj.account
-            old_amount = command.transaction_obj.amount
-            old_type = command.transaction_obj.type
-
-            self._apply_balance_for_delete(old_account, old_amount, old_type)
-            self._apply_balance_for_create(
-                command.account,
-                command.amount,
-                command.type_value,
+            transaction_obj = self.transaction_repository.get_by_id_for_update(
+                command.transaction_obj.pk,
             )
+            self._validate_transaction_owner(command.user, transaction_obj)
+            old_account = transaction_obj.account
+            old_amount = transaction_obj.amount
+            old_type = transaction_obj.type
 
-            command.transaction_obj.account = command.account
-            command.transaction_obj.category = command.category
-            command.transaction_obj.amount = command.amount
-            command.transaction_obj.type = command.type_value
+            deltas = {
+                old_account.pk: -self._balance_delta(old_amount, old_type),
+            }
+            deltas[command.account.pk] = deltas.get(
+                command.account.pk,
+                0,
+            ) + self._balance_delta(command.amount, command.type_value)
+            self.account_service.apply_account_deltas(deltas)
+
+            transaction_obj.account = command.account
+            transaction_obj.category = command.category
+            transaction_obj.amount = command.amount
+            transaction_obj.type = command.type_value
 
             date_value = command.transaction_date
             if isinstance(date_value, date) and not isinstance(
@@ -166,9 +187,9 @@ class TransactionService:
                 date_value,
             ):
                 date_value = timezone.make_aware(date_value)
-            command.transaction_obj.date = date_value
-            command.transaction_obj.save()
-        return command.transaction_obj
+            transaction_obj.date = date_value
+            transaction_obj.save()
+        return transaction_obj
 
     def delete_transaction(
         self,
@@ -179,6 +200,10 @@ class TransactionService:
         """Delete a transaction and reverse its effect on the account."""
         self._validate_transaction_owner(user, transaction_obj)
         with db_transaction.atomic():
+            transaction_obj = self.transaction_repository.get_by_id_for_update(
+                transaction_obj.pk,
+            )
+            self._validate_transaction_owner(user, transaction_obj)
             self._apply_balance_for_delete(
                 transaction_obj.account,
                 transaction_obj.amount,
@@ -193,12 +218,14 @@ class TransactionService:
         transaction_id: int,
     ) -> Transaction:
         """Duplicate an existing transaction and adjust the balance."""
-        original = self.transaction_repository.get_by_id(transaction_id)
-        if original.user != user:
-            raise PermissionDenied(
-                _('У вас нет прав на копирование этой операции.'),
-            )
         with db_transaction.atomic():
+            original = self.transaction_repository.get_by_id_for_update(
+                transaction_id,
+            )
+            if original.user != user:
+                raise PermissionDenied(
+                    _('У вас нет прав на копирование этой операции.'),
+                )
             new_transaction = self.transaction_repository.create_transaction(
                 user=original.user,
                 account=original.account,


### PR DESCRIPTION
## Summary
- serialize account balance mutations with row locks and stable multi-account ordering
- reconcile transactions, transfers, and receipt updates through signed atomic deltas
- fix receipt operation directions, API ownership checks, and API deletion consistency
- lock mutable transactions and receipts and validate account/category ownership
- add regressions for stale account instances and FNS receipt operation directions

## Validation
- `python manage.py test hasta_la_vista_money.finance_account.tests hasta_la_vista_money.transactions.tests hasta_la_vista_money.receipts.tests --keepdb` (436 tests passed, 1 skipped)
- focused post-hook regression suite (24 tests passed)
- `ruff check` and `ruff format --check` on changed files
- pre-commit hooks passed
- `git diff --check` passed

## Notes
- no database migration is required
- existing test-suite warnings for django-axes middleware and naive fixture datetimes remain unchanged